### PR TITLE
fix(fase3): aplicar 4 fixes críticos da Fase 3

### DIFF
--- a/libraries/python/neural_hive_risk_scoring/alerts.py
+++ b/libraries/python/neural_hive_risk_scoring/alerts.py
@@ -54,7 +54,7 @@ class RiskAlert:
     band: RiskBand
     message: str
     details: Dict[str, Any]
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     acknowledged: bool = False
     acknowledged_by: Optional[str] = None
     acknowledged_at: Optional[datetime] = None

--- a/libraries/python/neural_hive_risk_scoring/ensemble.py
+++ b/libraries/python/neural_hive_risk_scoring/ensemble.py
@@ -6,7 +6,7 @@ Combinação de múltiplos modelos de avaliação de risco para decisão robusta
 
 import structlog
 from typing import Dict, List, Optional, Tuple, Callable, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from enum import Enum
 from statistics import mean, median, stdev
@@ -110,7 +110,7 @@ class EnsembleResult:
     model_votes: Dict[str, Tuple[float, RiskBand]]  # model -> (score, band)
     confidence: float  # 0.0 a 1.0, quão confidente o ensemble está
     consensus_level: float  # 0.0 a 1.0, quão de acordo estão os modelos
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: Dict = field(default_factory=dict)
 
     def to_dict(self) -> Dict:

--- a/libraries/python/neural_hive_risk_scoring/explainability.py
+++ b/libraries/python/neural_hive_risk_scoring/explainability.py
@@ -6,7 +6,7 @@ Explicabilidade de decisões de risco com SHAP-like values e feature importance.
 
 import structlog
 from typing import Dict, List, Optional, Tuple
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass, field
 
 from .config import RiskBand, RiskScoringConfig
@@ -54,7 +54,7 @@ class RiskExplanation:
     base_score: float  # Score base sem fatores
     total_adjustment: float  # Ajuste total dos fatores
     reasoning: str
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: Dict = field(default_factory=dict)
 
     def to_dict(self) -> Dict:

--- a/libraries/python/neural_hive_risk_scoring/models.py
+++ b/libraries/python/neural_hive_risk_scoring/models.py
@@ -6,7 +6,7 @@ Modelos Pydantic para representação de avaliações de risco.
 
 from pydantic import BaseModel, Field, ConfigDict
 from typing import Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from .config import RiskBand
 from neural_hive_domain import UnifiedDomain
 
@@ -31,7 +31,7 @@ class RiskAssessment(BaseModel):
     domain: UnifiedDomain = Field(description="Domínio de avaliação")
     factors: Dict[str, float] = Field(description="Fatores individuais")
     reasoning: str = Field(description="Justificativa da avaliação")
-    assessed_at: datetime = Field(default_factory=datetime.utcnow)
+    assessed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
@@ -46,4 +46,4 @@ class RiskMatrix(BaseModel):
     overall_score: float = Field(ge=0.0, le=1.0)
     overall_band: RiskBand
     highest_risk_domain: UnifiedDomain
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/services/self-healing-engine/src/chaos/game_day_runner.py
+++ b/services/self-healing-engine/src/chaos/game_day_runner.py
@@ -16,7 +16,11 @@ import asyncio
 import json
 import sys
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .chaos_engine import ChaosEngine
+    from ..services.playbook_executor import PlaybookExecutor
 
 import structlog
 
@@ -53,6 +57,8 @@ class GameDayRunner:
         default_timeout: int = 600,
         require_opa: bool = True,
         blast_radius_limit: int = 5,
+        playbook_executor: Optional[Any] = None,
+        chaos_engine: Optional[Any] = None,
     ):
         """
         Inicializa o Game Day Runner.
@@ -64,6 +70,8 @@ class GameDayRunner:
             default_timeout: Timeout padrão em segundos
             require_opa: Se requer aprovação OPA
             blast_radius_limit: Limite de blast radius
+            playbook_executor: Executor de playbooks (opcional)
+            chaos_engine: Instância de ChaosEngine pré-configurada (opcional)
         """
         self.environment = environment
         self.k8s_in_cluster = k8s_in_cluster
@@ -71,8 +79,9 @@ class GameDayRunner:
         self.default_timeout = default_timeout
         self.require_opa = require_opa
         self.blast_radius_limit = blast_radius_limit
+        self.playbook_executor = playbook_executor
 
-        self.chaos_engine: Optional[ChaosEngine] = None
+        self.chaos_engine = chaos_engine
         self.scenario_library = ScenarioLibrary()
         self.reports: List[ExperimentReport] = []
 
@@ -80,17 +89,18 @@ class GameDayRunner:
         """Inicializa o ChaosEngine e dependências."""
         logger.info("game_day_runner.initializing")
 
-        self.chaos_engine = ChaosEngine(
-            k8s_in_cluster=self.k8s_in_cluster,
-            playbook_executor=None,
-            service_registry_client=None,
-            opa_client=None,
-            max_concurrent_experiments=self.max_concurrent,
-            default_timeout_seconds=self.default_timeout,
-            require_opa_approval=self.require_opa,
-            blast_radius_limit=self.blast_radius_limit,
-        )
-        await self.chaos_engine.initialize()
+        if not self.chaos_engine:
+            self.chaos_engine = ChaosEngine(
+                k8s_in_cluster=self.k8s_in_cluster,
+                playbook_executor=self.playbook_executor,
+                service_registry_client=None,
+                opa_client=None,
+                max_concurrent_experiments=self.max_concurrent,
+                default_timeout_seconds=self.default_timeout,
+                require_opa_approval=self.require_opa,
+                blast_radius_limit=self.blast_radius_limit,
+            )
+            await self.chaos_engine.initialize()
 
         logger.info("game_day_runner.initialized")
 

--- a/services/self-healing-engine/src/services/circuit_breaker.py
+++ b/services/self-healing-engine/src/services/circuit_breaker.py
@@ -103,6 +103,11 @@ class CircuitBreaker:
         """Timestamp da última falha."""
         return self._last_failure_time
 
+    @property
+    def is_open(self) -> bool:
+        """Retorna True se o circuit breaker está aberto (OPEN)."""
+        return self._state == CircuitBreakerState.OPEN
+
     def record_success(self):
         """
         Registra uma chamada bem-sucedida.

--- a/services/self-healing-engine/tests/test_chaos_injection.py
+++ b/services/self-healing-engine/tests/test_chaos_injection.py
@@ -173,7 +173,7 @@ async def test_chaos_game_day_runner():
 
     runner = GameDayRunner(playbook_executor=mock_executor, chaos_engine=mock_chaos)
 
-    result = await runner.run_game_day(name="test-gameday", scenarios=["pod_kill", "network_delay"])
+    result = await runner.run_game_day(scenarios=[{"scenario_name": "pod_kill", "target_service": "test-service"}, {"scenario_name": "network_delay", "target_service": "test-service"}])
 
     assert result is not None
 

--- a/services/sla-management-system/src/services/slo_manager.py
+++ b/services/sla-management-system/src/services/slo_manager.py
@@ -277,12 +277,12 @@ class SLOManager:
                 "layer": spec.get("layer"),
                 "target": spec.get("target"),
                 "windowDays": spec.get("windowDays", 30),
-                "sliQuery": {
-                    "metricName": sli_query_spec.get("metricName"),
-                    "query": sli_query_spec.get("query"),
-                    "aggregation": sli_query_spec.get("aggregation", "avg"),
-                    "labels": sli_query_spec.get("labels", {}),
-                },
+                "sliQuery": SLIQuery(
+                    metric_name=sli_query_spec.get("metricName"),
+                    query=sli_query_spec.get("query"),
+                    aggregation=sli_query_spec.get("aggregation", "avg"),
+                    labels=sli_query_spec.get("labels", {}),
+                ).model_dump(),
                 "enabled": spec.get("enabled", True),
                 "metadata": spec.get("metadata", {}),
             }


### PR DESCRIPTION
## Summary

Aplica 4 fixes críticos da Fase 3 que não foram incluídos nos PRs anteriores.

**Commits:**
1. `fix(slo)`: use SLIQuery instance instead of dict for CRD mapping
2. `fix(chaos)`: add is_open property to CircuitBreaker
3. `fix(chaos)`: align GameDayRunner constructor with tests
4. `fix(risk)`: substituir datetime.utcnow por datetime.now(timezone.utc) (RISK-001)

## Changes

- Correções no SLA management (CRD sync)
- Melhorias no Chaos Engineering Suite (CircuitBreaker, GameDayRunner)
- Fix de timezone no Risk Scoring (RISK-001)

## Testing

Commits incluem testes unitários.