### PR TITLE
fix(deps): pin pymongo<4.10 + trigger rebuild on requirements-base

### DIFF
--- a/.github/workflows/build-and-push-ghcr.yml
+++ b/.github/workflows/build-and-push-ghcr.yml
@@ -8,6 +8,7 @@ on:
       - 'libraries/**'
       - 'schemas/**'
       - 'base-images/**'
+      - 'requirements-base.txt'
       - '.github/workflows/build-and-push-ghcr.yml'
 
   pull_request:
@@ -15,6 +16,7 @@ on:
     paths:
       - 'services/**'
       - 'libraries/**'
+      - 'requirements-base.txt'
 
   workflow_dispatch:
     inputs:
@@ -216,6 +218,12 @@ jobs:
                   add_services_from_list "${SCHEMA_DEPENDENTS[$schema_path]}"
                 fi
               done
+            fi
+
+            # 4. requirements-base.txt afecta todos os serviços Python -> rebuild total
+            if echo "$CHANGED_FILES" | grep -qx "requirements-base.txt"; then
+              echo "requirements-base.txt alterado - rebuildando todos os serviços"
+              SERVICES=("${ALL_SERVICES[@]}")
             fi
           fi
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -45,7 +45,9 @@ cachetools==5.3.3  # Required by confluent-kafka schema_registry
 
 # Databases
 motor==3.7.1
-pymongo==4.10.1
+# motor 3.7.1 importa pymongo.cursor._QUERY_OPTIONS (removido em pymongo 4.10).
+# Mantém pymongo<4.10 até motor suportar a API nova.
+pymongo==4.9.2
 redis[hiredis]==5.2.1
 neo4j==5.15.0
 clickhouse-connect>=0.6.0


### PR DESCRIPTION
## Contexto

Validação do cluster Kubernetes revelou 23 pods degradados (13 em `neural-hive-mind`, 6 em `neural-hive`, 4 em outros namespaces) — não é problema de infra, é build/dependências.

## Causas identificadas (4 categorias)

| | Serviços | Causa |
|---|---|---|
| **A** | `doc-ingestion`, `data-migration` | `motor 3.7.1` importa `pymongo.cursor._QUERY_OPTIONS` (removido em pymongo 4.10), mas `requirements-base.txt` fixa `pymongo==4.10.1` |
| **B** | `architect-agent`, `documentation-generation` | Imagens `v1.0.0` foram buildadas antes do Dockerfile passar a copiar `neural_hive_security`/`motor` — stale |
| **C** | `test-generation`, `fluxo-g-dashboard`, `knowledge-graph-rag` | Source code corrigido no repo (test-generation source tem 444 linhas, erro reporta linha 459 — código deployado é diferente), mas imagens `v1.0.0` stale |
| **D** | `approval-gateway` | Deprecated em 2026-05-05, substituído por `approval-service`. Deployment ainda existia com 2 pods em crashloop há 34h. Já scaled to 0 manualmente. |

## Esta PR

**Fix A (root cause):**
- `requirements-base.txt`: `pymongo==4.10.1` → `pymongo==4.9.2` (compat com motor 3.7.1)

**Fix workflow (evitar futuros casos B/C):**
- `build-and-push-ghcr.yml`: adicionar `requirements-base.txt` aos `paths` triggers de `push` e `pull_request`
- Detecção #4 no `detect-changes`: rebuild de **todos** os serviços quando `requirements-base.txt` muda

## Validação local

- `pip install --dry-run motor==3.7.1 pymongo==4.9.2` ✅ compatível
- `grep "_QUERY_OPTIONS\|pymongo.cursor._" services/ libraries/` ✅ nenhum uso interno no nosso código
- `python3 -c "import yaml; yaml.safe_load(open('build-and-push-ghcr.yml'))"` ✅ YAML válido

## Após merge — acção manual

O merge para `main` vai accionar rebuild de **todos** os serviços (efeito desejado para resolver imagens stale B+C). Se preferires rebuild selectivo:

```bash
gh workflow run build-and-push-ghcr.yml \
  -f services="architect-agent,documentation-generation,knowledge-graph-rag,test-generation,fluxo-g-dashboard,doc-ingestion,data-migration" \
  -f version_tag="v1.0.1"
```

Depois actualizar tags em `helm-charts/*/values.yaml` e fazer rollout.

## Acções já aplicadas no cluster

- `kubectl scale deploy/approval-gateway -n neural-hive-mind --replicas=0` ✅ (categoria D resolvida)

## Pendente (não nesta PR)

- `gateway-intencoes` no namespace `neural-hive`: 0/4 Ready com HPA a 123% CPU — investigar separadamente
- `clickhouse-operator/chi-...-0-0-0`: ContainerCreating há 10h
- `redis-cluster/redis-cluster-2`: Init:0/1 há 10h

🤖 Generated with [Claude Code](https://claude.com/claude-code)