### PR TITLE
fix(dockerfiles): copy requirements-base.txt in 11 build files

### DIFF
--- a/services/approval-service/Dockerfile
+++ b/services/approval-service/Dockerfile
@@ -17,9 +17,11 @@ COPY libraries/python/neural_hive_domain /tmp/neural_hive_domain
 COPY libraries/python/neural_hive_specialists /tmp/neural_hive_specialists
 COPY libraries/python/neural_hive_observability /tmp/neural_hive_observability
 
-# Copy requirements and install dependencies
-COPY services/approval-service/requirements.txt .
-RUN pip install --no-cache-dir --user /tmp/neural_hive_domain && \
+# Copy requirements (base + service) and install dependencies
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/approval-service/requirements.txt ./requirements-service.txt
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir --user /tmp/neural_hive_domain && \
     pip install --no-cache-dir --user /tmp/neural_hive_specialists && \
     pip install --no-cache-dir --user /tmp/neural_hive_observability && \
     pip install --no-cache-dir --user -r requirements.txt && \

--- a/services/consensus-engine/Dockerfile
+++ b/services/consensus-engine/Dockerfile
@@ -7,9 +7,11 @@ WORKDIR /app
 # Copy internal library for installation
 COPY libraries/python/neural_hive_domain /tmp/neural_hive_domain
 
-# Instalar dependências e biblioteca interna
-COPY services/consensus-engine/requirements.txt .
+# Instalar dependências (base + service) e biblioteca interna
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/consensus-engine/requirements.txt ./requirements-service.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
+    sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
     pip install --no-cache-dir --user /tmp/neural_hive_domain && \
     pip install --no-cache-dir --user -r requirements.txt && \
     python -m uvicorn --version && \

--- a/services/consensus-engine/requirements.txt
+++ b/services/consensus-engine/requirements.txt
@@ -2,7 +2,7 @@
 -r ../../requirements-base.txt
 
 # Kafka - extras
-cachetools==5.5.0  # Required by confluent-kafka==2.8.0 schema_registry
+# cachetools vem de requirements-base.txt (==5.3.3, compatível com confluent-kafka 2.8.0)
 attrs>=23.1.0
 authlib>=1.3.0
 

--- a/services/execution-ticket-service/Dockerfile
+++ b/services/execution-ticket-service/Dockerfile
@@ -13,9 +13,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copiar e instalar dependências Python diretamente no sistema
-COPY services/execution-ticket-service/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Copiar requirements (base + service) e instalar dependências Python diretamente no sistema
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/execution-ticket-service/requirements.txt ./requirements-service.txt
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt
 
 # Copiar código fonte
 COPY services/execution-ticket-service/src/ ./src/

--- a/services/explainability-api/Dockerfile
+++ b/services/explainability-api/Dockerfile
@@ -10,11 +10,13 @@ RUN apt-get update && apt-get install -y \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
-# Copiar requirements
-COPY services/explainability-api/requirements.txt .
+# Copiar requirements (base + service)
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/explainability-api/requirements.txt ./requirements-service.txt
 
-# Instalar dependências Python (filtrando as já presentes na base image)
-RUN grep -vE "neural_hive_observability|opentelemetry-|prometheus-client|structlog|pydantic" requirements.txt > requirements-filtered.txt && \
+# Instalar dependências Python (resolvendo path base e filtrando as já presentes na base image)
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    grep -vE "neural_hive_observability|opentelemetry-|prometheus-client|structlog|pydantic" requirements.txt > requirements-filtered.txt && \
     pip install --no-cache-dir --user -r requirements-filtered.txt
 
 # Stage 2: Runtime (herda da base de observabilidade com todos os pacotes)

--- a/services/gateway-intencoes/Dockerfile
+++ b/services/gateway-intencoes/Dockerfile
@@ -50,6 +50,7 @@ COPY libraries/python/neural_hive_security /tmp/neural_hive_security
 # Copiar biblioteca neural_hive_observability atualizada (sobrescreve versão da imagem base)
 # Necessário para incluir correções de headers OTEL gRPC lowercase
 COPY libraries/python/neural_hive_observability /tmp/neural_hive_observability
+COPY libraries/python/neural_hive_specialists /tmp/neural_hive_specialists
 
 # Instalar dependências Python em uma única camada para otimizar build
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -57,10 +58,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-cache-dir /tmp/neural_hive_domain && \
     pip install --no-cache-dir /tmp/neural_hive_security && \
     pip install --no-cache-dir --force-reinstall /tmp/neural_hive_observability && \
-    cat requirements-service.txt | sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' > requirements.txt && \
+    pip install --no-cache-dir /tmp/neural_hive_specialists && \
+    sed -e 's|-r ../../requirements-base.txt|-r requirements-base.txt|' \
+        -e '/^-e \.\.\/\.\.\/libraries\//d' \
+        requirements-service.txt > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir --no-deps openai-whisper && \
-    rm -rf /tmp/neural_hive_domain /tmp/neural_hive_security /tmp/neural_hive_observability
+    rm -rf /tmp/neural_hive_domain /tmp/neural_hive_security /tmp/neural_hive_observability /tmp/neural_hive_specialists
 
 # Baixar modelos spaCy para todos os idiomas suportados (pt, en, es)
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/services/gateway-intencoes/requirements.txt
+++ b/services/gateway-intencoes/requirements.txt
@@ -6,10 +6,8 @@ torch>=2.1.0
 tiktoken>=0.5.0
 openai-whisper>=20230314  # ASR pipeline
 
-# gRPC clients para NLU/PII services (T11)
-grpcio==1.68.0
-grpcio-tools==1.68.0
-protobuf==5.29.1
+# gRPC clients para NLU/PII services (T11) — versões vêm de requirements-base.txt
+# (grpcio==1.71.2, grpcio-tools==1.71.2, protobuf==5.29.2)
 
 # Libraries Neural Hive-Mind
 -e ../../libraries/python/neural_hive_observability

--- a/services/mcp-tool-catalog/Dockerfile
+++ b/services/mcp-tool-catalog/Dockerfile
@@ -14,9 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Copy requirements and install dependencies to venv
-COPY services/mcp-tool-catalog/requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip && \
+# Copy requirements (base + service) and install dependencies to venv
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/mcp-tool-catalog/requirements.txt ./requirements-service.txt
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Copy and install neural_hive_resilience FIRST (dependency of integration)

--- a/services/memory-layer-api/Dockerfile
+++ b/services/memory-layer-api/Dockerfile
@@ -12,9 +12,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements and install dependencies into system Python (alongside neural_hive_observability)
-COPY services/memory-layer-api/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Copy requirements (base + service) and install dependencies into system Python
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/memory-layer-api/requirements.txt ./requirements-service.txt
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt
 
 # Create non-root user
 RUN useradd -m -u 1000 app

--- a/services/scout-agents/Dockerfile
+++ b/services/scout-agents/Dockerfile
@@ -13,11 +13,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy libraries needed for requirements.txt
 COPY libraries /libraries
 
-# Copy requirements and install dependencies in virtualenv with system site-packages
-COPY services/scout-agents/requirements.txt .
+# Copy requirements (base + service) and install dependencies in virtualenv with system site-packages
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/scout-agents/requirements.txt ./requirements-service.txt
 RUN python -m venv --system-site-packages /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-RUN pip install --no-cache-dir --upgrade pip && \
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir /libraries/python/neural_hive_resilience/ && \
     pip install --no-cache-dir /libraries/neural_hive_integration/

--- a/services/semantic-translation-engine/Dockerfile
+++ b/services/semantic-translation-engine/Dockerfile
@@ -17,9 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY libraries/python/neural_hive_domain /tmp/neural_hive_domain
 COPY libraries/python/neural_hive_observability /tmp/neural_hive_observability
 
-# Copy requirements and install dependencies
-COPY services/semantic-translation-engine/requirements.txt .
-RUN pip install --no-cache-dir --user /tmp/neural_hive_domain && \
+# Copy requirements (base + service) and install dependencies
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/semantic-translation-engine/requirements.txt ./requirements-service.txt
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir --user /tmp/neural_hive_domain && \
     pip install --no-cache-dir --user /tmp/neural_hive_observability && \
     pip install --no-cache-dir --user -r requirements.txt && \
     python -m uvicorn --version && \

--- a/services/sla-management-system/Dockerfile
+++ b/services/sla-management-system/Dockerfile
@@ -11,9 +11,11 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements and install dependencies to user directory
-COPY services/sla-management-system/requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip && \
+# Copy requirements (base + service) and install dependencies to user directory
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/sla-management-system/requirements.txt ./requirements-service.txt
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir --user -r requirements.txt
 
 # Stage 2: Runtime - use same base to keep neural_hive_observability

--- a/services/worker-agents/Dockerfile
+++ b/services/worker-agents/Dockerfile
@@ -16,9 +16,11 @@ WORKDIR /app
 COPY libraries/neural_hive_integration /tmp/neural_hive_integration
 COPY libraries/python/neural_hive_resilience /tmp/neural_hive_resilience
 
-# Copy requirements and install dependencies
-COPY services/worker-agents/requirements.txt .
-RUN pip install --no-cache-dir --user /tmp/neural_hive_resilience && \
+# Copy requirements (base + service) and install dependencies
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/worker-agents/requirements.txt ./requirements-service.txt
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir --user /tmp/neural_hive_resilience && \
     pip install --no-cache-dir --user /tmp/neural_hive_integration && \
     pip install --no-cache-dir --user -r requirements.txt
 


### PR DESCRIPTION
Sequela da PR #64. Onze Dockerfiles falhavam o build com 'Could not open requirements file: /requirements-base.txt'.

Fix: aplica o padrão de architect-agent — COPY requirements-base.txt + sed para reescrever path relativo.

Serviços: approval-service, consensus-engine, execution-ticket-service, explainability-api, gateway-intencoes, mcp-tool-catalog, memory-layer-api, scout-agents, semantic-translation-engine, sla-management-system, worker-agents.

Caso especial gateway-intencoes: filtra também '-e ../../libraries/...' do requirements.txt e adiciona neural_hive_specialists às libs copiadas para /tmp.

Recomenda merge após #64.