### PR TITLE
fix(opa): copy rego policies into chart for .Files.Get

### DIFF
--- a/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/feature_flags.rego
+++ b/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/feature_flags.rego
@@ -1,0 +1,173 @@
+package neuralhive.orchestrator.feature_flags
+
+# Resultado principal - decisões booleanas sobre features
+result := {
+    "enable_intelligent_scheduler": enable_intelligent_scheduler,
+    "enable_burst_capacity": enable_burst_capacity,
+    "enable_predictive_allocation": enable_predictive_allocation,
+    "enable_auto_scaling": enable_auto_scaling,
+    "enable_experimental_features": enable_experimental_features
+}
+
+# Feature 1: Intelligent Scheduler
+default enable_intelligent_scheduler := false
+enable_intelligent_scheduler {
+    # Flag global habilitada
+    input.flags.intelligent_scheduler_enabled == true
+
+    # Namespace permitido
+    namespace := input.context.namespace
+    is_namespace_allowed(namespace, input.flags.scheduler_namespaces)
+
+    # Para critical/high, sempre habilitar se flag global está ativa
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    risk_band_allows_scheduler(risk_band)
+}
+
+enable_intelligent_scheduler {
+    # Flag global habilitada
+    input.flags.intelligent_scheduler_enabled == true
+
+    # Namespace permitido
+    namespace := input.context.namespace
+    is_namespace_allowed(namespace, input.flags.scheduler_namespaces)
+
+    # Para medium/low, habilitar se não estiver em rollout gradual
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    not risk_band_allows_scheduler(risk_band)
+    not input.flags.gradual_rollout
+}
+
+# Feature 2: Burst Capacity
+default enable_burst_capacity := false
+enable_burst_capacity {
+    # Flag global habilitada
+    input.flags.burst_capacity_enabled == true
+
+    # Carga atual está abaixo do threshold
+    current_load := input.context.current_load
+    threshold := input.flags.burst_threshold
+    current_load < threshold
+
+    # Tenant é premium
+    tenant_id := input.context.tenant_id
+    is_tenant_premium(tenant_id, input.flags.premium_tenants)
+}
+
+enable_burst_capacity {
+    # Flag global habilitada
+    input.flags.burst_capacity_enabled == true
+
+    # Carga atual está abaixo do threshold
+    current_load := input.context.current_load
+    threshold := input.flags.burst_threshold
+    current_load < threshold
+
+    # Ou risk_band é critical (sempre permitir burst)
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    risk_band == "critical"
+}
+
+# Feature 3: Predictive Allocation
+default enable_predictive_allocation := false
+enable_predictive_allocation {
+    # Flag global habilitada
+    input.flags.predictive_allocation_enabled == true
+
+    # Acurácia do modelo suficiente
+    model_accuracy := input.context.model_accuracy
+    model_accuracy > 0.85
+
+    # Namespace em beta testing
+    namespace := input.context.namespace
+    is_namespace_in_beta(namespace)
+}
+
+# Feature 4: Auto-scaling
+default enable_auto_scaling := false
+enable_auto_scaling {
+    # Flag global habilitada
+    input.flags.auto_scaling_enabled == true
+
+    # Queue depth acima do threshold
+    queue_depth := input.context.queue_depth
+    threshold := input.flags.scaling_threshold
+    queue_depth > threshold
+
+    # Dentro da janela de tempo permitida
+    current_time := input.context.current_time
+    is_within_business_hours(current_time)
+}
+
+# Feature 5: Experimental Features
+default enable_experimental_features := false
+enable_experimental_features {
+    # Namespace de desenvolvimento/staging
+    namespace := input.context.namespace
+    is_development_namespace(namespace)
+}
+
+enable_experimental_features {
+    # Tenant optou por early access
+    tenant_id := input.context.tenant_id
+    is_early_access_tenant(tenant_id)
+}
+
+# Helpers
+
+is_namespace_allowed(namespace, allowed_list) {
+    allowed_list[_] == namespace
+}
+
+is_tenant_premium(tenant_id, premium_list) {
+    premium_list[_] == tenant_id
+}
+
+is_tenant_premium(tenant_id, premium_list) {
+    # Se lista vazia, nenhum tenant é premium
+    count(premium_list) == 0
+    false
+}
+
+risk_band_allows_scheduler(risk_band) {
+    risk_band == "critical"
+}
+
+risk_band_allows_scheduler(risk_band) {
+    risk_band == "high"
+}
+
+is_namespace_in_beta(namespace) {
+    namespace == "staging"
+}
+
+is_namespace_in_beta(namespace) {
+    namespace == "beta"
+}
+
+is_development_namespace(namespace) {
+    namespace == "development"
+}
+
+is_development_namespace(namespace) {
+    namespace == "dev"
+}
+
+is_development_namespace(namespace) {
+    namespace == "staging"
+}
+
+is_early_access_tenant(tenant_id) {
+    # Implementar lógica de early access
+    # Por enquanto, sempre false
+    false
+}
+
+is_within_business_hours(current_time) {
+    # Simplificado: sempre permitir por enquanto
+    # TODO: Implementar lógica de horário comercial
+    true
+}

--- a/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/http_authz.rego
+++ b/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/http_authz.rego
@@ -1,0 +1,107 @@
+package neuralhive.orchestrator.authz
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+default allow := false
+
+# Endpoints públicos - sempre permitem sem autenticação
+public_paths := [
+    "/health",
+    "/healthz",
+    "/ready",
+    "/metrics",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/favicon.ico",
+    "/static",
+]
+
+# Regra 1: Paths públicos são sempre permitidos
+allow if {
+    path := input.request.path
+    some public_path in public_paths
+    startswith(path, public_path)
+}
+
+# Regra 2: Admins podem acessar tudo
+allow if {
+    input.user.role == "admin"
+}
+
+# Regra 3: Developers podem fazer GET em APIs
+allow if {
+    input.user.role == "developer"
+    input.request.method == "GET"
+    startswith(input.request.path, "/api/")
+    tenant_isolation_valid(input.request.path, input.user)
+}
+
+# Regra 4: Tenantes autenticados podem acessar recursos próprios
+allow if {
+    is_authenticated(input.user)
+    not input.user.role in ["admin", "developer", "worker"]  # Admin, developer, worker têm regras próprias
+    input.request.method in ["GET", "POST", "PUT", "DELETE"]
+    startswith(input.request.path, "/api/v1/")
+    not is_admin_endpoint(input.request.path)  # Admin endpoints bloqueados
+    tenant_isolation_valid(input.request.path, input.user)
+}
+
+# Regra 4b: Endpoints genéricos são permitidos para usuários autenticados
+allow if {
+    is_authenticated(input.user)
+    is_generic_api_endpoint(input.request.path)
+    input.request.method in ["GET", "POST", "PUT", "DELETE"]
+}
+
+# Regra 5: Workers (service accounts) podem acessar endpoints específicos
+allow if {
+    input.user.role == "worker"
+    input.request.method in ["GET", "POST"]
+    startswith(input.request.path, "/api/v1/workers/")
+}
+
+# Regra 6: Service Registry pode registrar/desregistrar workers
+allow if {
+    input.user.role == "service-registry"
+    input.request.method in ["POST", "DELETE"]
+    input.request.path == "/api/v1/workers/register"
+}
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+# Verifica se o usuário está autenticado (não é anonymous)
+is_authenticated(user) if {
+    user.id != "anonymous"
+    user.id != ""
+    user.id != null
+}
+
+# Verifica se path é um endpoint administrativo
+is_admin_endpoint(path) if {
+    parts := split(path, "/")
+    count(parts) >= 4
+    parts[3] in ["admin", "delete", "sudo", "internal"]
+}
+
+# Helper: Verifica se endpoint é genérico (sem tenant_id no path)
+is_generic_api_endpoint(path) if {
+    parts := split(path, "/")
+    # Endpoints como /api/v1/workflows, /api/v1/tickets (sem tenant_id)
+    count(parts) == 4  # ["", "api", "v1", "endpoint"]
+}
+
+# Verifica isolamento de tenant - o tenant_id no path deve corresponder ao tenant do usuário
+tenant_isolation_valid(path, user) if {
+    # Extrair tenant_id do path: /api/v1/{tenant_id}/...
+    # Array split: ["", "api", "v1", "{tenant_id}", ...]
+    # Índice [3] contém o tenant_id
+    parts := split(path, "/")
+    count(parts) >= 5
+    path_tenant_id := parts[3]
+    path_tenant_id == user.tenant_id
+}

--- a/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/resource_limits.rego
+++ b/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/resource_limits.rego
@@ -1,0 +1,176 @@
+package neuralhive.orchestrator.resource_limits
+
+# Limites de timeout por risk_band (em milissegundos)
+timeout_limits := {
+    "critical": 7200000,  # 2h
+    "high": 3600000,      # 1h
+    "medium": 1800000,    # 30min
+    "low": 900000         # 15min
+}
+
+# Limites de retries por risk_band
+retry_limits := {
+    "critical": 5,
+    "high": 3,
+    "medium": 2,
+    "low": 1
+}
+
+# Resultado principal
+result := {
+    "allow": allow,
+    "violations": violations,
+    "warnings": warnings
+}
+
+# Allow se não houver violações
+default allow := false
+allow {
+    count(violations) == 0
+}
+
+# Coletar todas as violações
+violations[violation] {
+    violation := timeout_exceeds_maximum
+}
+
+violations[violation] {
+    violation := retries_exceed_maximum
+}
+
+violations[violation] {
+    violation := estimated_duration_unrealistic
+}
+
+violations[violation] {
+    violation := capabilities_not_allowed[_]
+}
+
+violations[violation] {
+    violation := concurrent_tickets_limit_exceeded
+}
+
+# Coletar warnings
+warnings := []
+
+# Regra 1: Timeout excede máximo
+timeout_exceeds_maximum := violation {
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    timeout_ms := ticket.sla.timeout_ms
+    max_timeout := timeout_limits[risk_band]
+
+    timeout_ms > max_timeout
+
+    violation := {
+        "policy": "resource_limits",
+        "rule": "timeout_exceeds_maximum",
+        "severity": "high",
+        "field": "sla.timeout_ms",
+        "msg": sprintf("Timeout de %vms excede máximo de %vms para risk_band=%v", [timeout_ms, max_timeout, risk_band]),
+        "expected": max_timeout,
+        "actual": timeout_ms
+    }
+}
+
+# Regra 2: Retries excedem máximo
+retries_exceed_maximum := violation {
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    max_retries := ticket.sla.max_retries
+    max_allowed := retry_limits[risk_band]
+
+    max_retries > max_allowed
+
+    violation := {
+        "policy": "resource_limits",
+        "rule": "retries_exceed_maximum",
+        "severity": "medium",
+        "field": "sla.max_retries",
+        "msg": sprintf("Max_retries de %v excede máximo de %v para risk_band=%v", [max_retries, max_allowed, risk_band]),
+        "expected": max_allowed,
+        "actual": max_retries
+    }
+}
+
+# Regra 3: Estimated duration unrealistic
+estimated_duration_unrealistic := violation {
+    ticket := input.resource
+    estimated_ms := ticket.estimated_duration_ms
+    timeout_ms := ticket.sla.timeout_ms
+
+    # Muito curto (<1s) ou maior que timeout
+    condition := estimated_ms < 1000
+    condition
+
+    violation := {
+        "policy": "resource_limits",
+        "rule": "estimated_duration_unrealistic",
+        "severity": "low",
+        "field": "estimated_duration_ms",
+        "msg": sprintf("Estimated_duration de %vms é muito curto (mínimo 1000ms)", [estimated_ms]),
+        "expected": ">=1000",
+        "actual": estimated_ms
+    }
+}
+
+estimated_duration_unrealistic := violation {
+    ticket := input.resource
+    estimated_ms := ticket.estimated_duration_ms
+    timeout_ms := ticket.sla.timeout_ms
+
+    estimated_ms >= timeout_ms
+
+    violation := {
+        "policy": "resource_limits",
+        "rule": "estimated_duration_unrealistic",
+        "severity": "medium",
+        "field": "estimated_duration_ms",
+        "msg": sprintf("Estimated_duration de %vms não pode ser >= timeout de %vms", [estimated_ms, timeout_ms]),
+        "expected": sprintf("<%v", [timeout_ms]),
+        "actual": estimated_ms
+    }
+}
+
+# Regra 4: Capabilities não permitidas
+capabilities_not_allowed[violation] {
+    ticket := input.resource
+    allowed := input.parameters.allowed_capabilities
+
+    required_cap := ticket.required_capabilities[_]
+    not is_capability_allowed(required_cap, allowed)
+
+    violation := {
+        "policy": "resource_limits",
+        "rule": "capabilities_not_allowed",
+        "severity": "high",
+        "field": "required_capabilities",
+        "msg": sprintf("Capability '%v' não está na whitelist", [required_cap]),
+        "expected": allowed,
+        "actual": required_cap
+    }
+}
+
+# Regra 5: Limite de tickets concorrentes
+concurrent_tickets_limit_exceeded := violation {
+    context := input.context
+    total_tickets := context.total_tickets
+    max_tickets := input.parameters.max_concurrent_tickets
+
+    total_tickets > max_tickets
+
+    violation := {
+        "policy": "resource_limits",
+        "rule": "concurrent_tickets_limit",
+        "severity": "high",
+        "field": "total_tickets",
+        "msg": sprintf("Total de %v tickets excede limite de %v tickets concorrentes", [total_tickets, max_tickets]),
+        "expected": max_tickets,
+        "actual": total_tickets
+    }
+}
+
+# Helper: Verificar se capability está permitida
+is_capability_allowed(capability, allowed_list) {
+    allowed_list[_] == capability
+}

--- a/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/security_constraints.rego
+++ b/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/security_constraints.rego
@@ -1,0 +1,511 @@
+package neuralhive.orchestrator.security_constraints
+
+# Resultado principal
+result := {
+    "allow": allow,
+    "violations": violations,
+    "warnings": warnings,
+    "security_context": security_context
+}
+
+# Allow se não houver violações críticas/high
+default allow := false
+allow {
+    count([v | v := violations[_]; v.severity == "critical"]) == 0
+    count([v | v := violations[_]; v.severity == "high"]) == 0
+}
+
+# Coletar violações
+violations[violation] {
+    violation := cross_tenant_access_violation
+}
+
+violations[violation] {
+    violation := missing_authentication_violation
+}
+
+violations[violation] {
+    violation := invalid_jwt_violation
+}
+
+violations[violation] {
+    violation := jwt_expired_violation
+}
+
+violations[violation] {
+    violation := jwt_invalid_issuer_violation
+}
+
+violations[violation] {
+    violation := jwt_invalid_audience_violation
+}
+
+violations[violation] {
+    violation := jwt_invalid_spiffe_id_violation
+}
+
+violations[violation] {
+    violation := jwt_missing_required_claims_violation
+}
+
+violations[violation] {
+    violation := jwt_jwks_unavailable_violation
+}
+
+violations[violation] {
+    violation := insufficient_permissions_violation
+}
+
+violations[violation] {
+    violation := pii_handling_violation
+}
+
+violations[violation] {
+    violation := tenant_rate_limit_exceeded_violation
+}
+
+# Regra 1: Cross-tenant access
+cross_tenant_access_violation := violation {
+    ticket := input.resource
+    ticket_tenant := ticket.tenant_id
+    allowed_tenants := input.security.allowed_tenants
+    
+    not tenant_is_allowed(ticket_tenant, allowed_tenants)
+    
+    violation := {
+        "policy": "security_constraints",
+        "rule": "cross_tenant_access",
+        "severity": "critical",
+        "field": "tenant_id",
+        "msg": sprintf("Tenant %v não está na whitelist de tenants permitidos", [ticket_tenant]),
+        "expected": allowed_tenants,
+        "actual": ticket_tenant
+    }
+}
+
+# Regra 2: Missing authentication
+missing_authentication_violation := violation {
+    context := input.context
+    spiffe_enabled := input.security.spiffe_enabled
+    
+    spiffe_enabled == true
+    not context.jwt_token
+    
+    violation := {
+        "policy": "security_constraints",
+        "rule": "missing_authentication",
+        "severity": "critical",
+        "field": "context.jwt_token",
+        "msg": "SPIFFE JWT token ausente quando autenticação está habilitada",
+        "expected": "JWT token válido",
+        "actual": null
+    }
+}
+
+# Regra 3: Invalid JWT (validação completa com io.jwt.decode_verify)
+invalid_jwt_violation := violation {
+    context := input.context
+    jwt_token := context.jwt_token
+
+    jwt_token != null
+    not is_valid_jwt_with_verification(jwt_token)
+
+    violation := {
+        "policy": "security_constraints",
+        "rule": "invalid_jwt",
+        "severity": "critical",
+        "field": "context.jwt_token",
+        "msg": "JWT token inválido: assinatura não verificada ou claims obrigatórios ausentes",
+        "expected": "JWT válido com assinatura verificada e claims obrigatórios (sub, exp, iat, tenant_id, roles)",
+        "actual": "JWT inválido"
+    }
+}
+
+# Regra 3.1: JWT expirado
+jwt_expired_violation := violation {
+    context := input.context
+    jwt_token := context.jwt_token
+
+    jwt_token != null
+    is_valid_jwt_structure(jwt_token)
+
+    # Decodificar payload para verificar exp
+    [header, payload, signature] := io.jwt.decode(jwt_token)
+    exp := payload.exp
+    current_time := time.now_ns() / 1000000000  # Converter para segundos
+
+    exp < current_time
+
+    violation := {
+        "policy": "security_constraints",
+        "rule": "jwt_expired",
+        "severity": "critical",
+        "field": "context.jwt_token",
+        "msg": sprintf("JWT expirado (exp: %v, current: %v)", [exp, current_time]),
+        "expected": "JWT não expirado",
+        "actual": exp
+    }
+}
+
+# Regra 3.2: JWT issuer inválido
+jwt_invalid_issuer_violation := violation {
+    context := input.context
+    jwt_token := context.jwt_token
+    expected_issuer := input.security.jwt_issuer
+
+    jwt_token != null
+    expected_issuer != null
+
+    [header, payload, signature] := io.jwt.decode(jwt_token)
+    iss := payload.iss
+
+    iss != expected_issuer
+
+    violation := {
+        "policy": "security_constraints",
+        "rule": "jwt_invalid_issuer",
+        "severity": "high",
+        "field": "context.jwt_token",
+        "msg": sprintf("JWT issuer inválido (esperado: %v, atual: %v)", [expected_issuer, iss]),
+        "expected": expected_issuer,
+        "actual": iss
+    }
+}
+
+# Regra 3.3: JWT audience inválido
+jwt_invalid_audience_violation := violation {
+    context := input.context
+    jwt_token := context.jwt_token
+    expected_audience := input.security.jwt_audience
+
+    jwt_token != null
+    expected_audience != null
+
+    [header, payload, signature] := io.jwt.decode(jwt_token)
+    aud := payload.aud
+
+    # aud pode ser string ou array
+    not audience_matches(aud, expected_audience)
+
+    violation := {
+        "policy": "security_constraints",
+        "rule": "jwt_invalid_audience",
+        "severity": "high",
+        "field": "context.jwt_token",
+        "msg": sprintf("JWT audience inválido (esperado: %v, atual: %v)", [expected_audience, aud]),
+        "expected": expected_audience,
+        "actual": aud
+    }
+}
+
+# Regra 3.4: SPIFFE ID inválido no subject
+jwt_invalid_spiffe_id_violation := violation {
+    context := input.context
+    jwt_token := context.jwt_token
+    trust_domain := input.security.spiffe_trust_domain
+
+    jwt_token != null
+    trust_domain != null
+
+    [header, payload, signature] := io.jwt.decode(jwt_token)
+    sub := payload.sub
+
+    # Subject deve ser um SPIFFE ID válido
+    not startswith(sub, sprintf("spiffe://%v/", [trust_domain]))
+
+    violation := {
+        "policy": "security_constraints",
+        "rule": "jwt_invalid_spiffe_id",
+        "severity": "critical",
+        "field": "context.jwt_token",
+        "msg": sprintf("SPIFFE ID inválido no JWT subject (esperado trust domain: %v, atual: %v)", [trust_domain, sub]),
+        "expected": sprintf("spiffe://%v/...", [trust_domain]),
+        "actual": sub
+    }
+}
+
+# Regra 3.5: Claims obrigatórios ausentes (tenant_id, roles)
+jwt_missing_required_claims_violation := violation {
+    context := input.context
+    jwt_token := context.jwt_token
+
+    jwt_token != null
+    is_valid_jwt_structure(jwt_token)
+
+    [header, payload, signature] := io.jwt.decode(jwt_token)
+
+    # Verificar claims obrigatórios
+    required_claims := ["sub", "exp", "iat", "tenant_id", "roles"]
+    missing_claim := required_claims[_]
+    not payload[missing_claim]
+
+    violation := {
+        "policy": "security_constraints",
+        "rule": "jwt_missing_required_claims",
+        "severity": "critical",
+        "field": "context.jwt_token",
+        "msg": sprintf("JWT ausente claim obrigatório: %v", [missing_claim]),
+        "expected": required_claims,
+        "actual": missing_claim
+    }
+}
+
+# Regra 3.6: JWKS indisponível (fail-closed)
+# Esta violação é gerada quando:
+# 1. JWT token está presente
+# 2. JWKS não está disponível (nem via data nem via http.send)
+# 3. Fallback sem assinatura NÃO está habilitado (jwt_allow_unsigned_fallback != true)
+jwt_jwks_unavailable_violation := violation {
+    context := input.context
+    jwt_token := context.jwt_token
+
+    jwt_token != null
+    is_valid_jwt_structure(jwt_token)
+
+    # JWKS não disponível
+    not get_spire_jwks
+
+    # Fallback não permitido (comportamento seguro padrão)
+    not input.security.jwt_allow_unsigned_fallback == true
+
+    violation := {
+        "policy": "security_constraints",
+        "rule": "jwt_jwks_unavailable",
+        "severity": "critical",
+        "field": "context.jwt_token",
+        "msg": "JWKS indisponível para verificação de assinatura JWT. Configurar jwks_url ou data.spire_jwks",
+        "expected": "JWKS disponível via data.spire_jwks ou input.security.jwks_url",
+        "actual": "JWKS não encontrado"
+    }
+}
+
+# Regra 4: Insufficient permissions (RBAC)
+insufficient_permissions_violation := violation {
+    ticket := input.resource
+    context := input.context
+    rbac_roles := input.security.rbac_roles
+    
+    user_id := context.user_id
+    user_roles := rbac_roles[user_id]
+    required_capability := ticket.required_capabilities[_]
+    
+    not has_capability_permission(user_roles, required_capability)
+    
+    violation := {
+        "policy": "security_constraints",
+        "rule": "insufficient_permissions",
+        "severity": "high",
+        "field": "required_capabilities",
+        "msg": sprintf("Usuário %v não tem permissão para capability %v", [user_id, required_capability]),
+        "expected": sprintf("Role com permissão para %v", [required_capability]),
+        "actual": user_roles
+    }
+}
+
+# Regra 5: PII handling violation
+pii_handling_violation := violation {
+    ticket := input.resource
+    contains_pii := ticket.contains_pii
+    data_classification := ticket.data_classification
+    
+    contains_pii == true
+    data_classification != "confidential"
+    
+    violation := {
+        "policy": "security_constraints",
+        "rule": "pii_handling_violation",
+        "severity": "high",
+        "field": "data_classification",
+        "msg": "Dados com PII devem ter classificação 'confidential'",
+        "expected": "confidential",
+        "actual": data_classification
+    }
+}
+
+# Regra 6: Tenant rate limit exceeded
+tenant_rate_limit_exceeded_violation := violation {
+    ticket := input.resource
+    context := input.context
+    tenant_id := ticket.tenant_id
+
+    limit := tenant_limit(tenant_id)
+    request_count := context.request_count_last_minute
+    request_count > limit
+
+    violation := {
+        "policy": "security_constraints",
+        "rule": "tenant_rate_limit_exceeded",
+        "severity": "medium",
+        "field": "request_count_last_minute",
+        "msg": sprintf("Tenant %v excedeu rate limit de %v req/min (atual: %v)", [tenant_id, limit, request_count]),
+        "expected": limit,
+        "actual": request_count
+    }
+}
+
+tenant_limit(tenant_id) = limit {
+    limit := input.security.tenant_rate_limits[tenant_id]
+} else = limit {
+    limit := input.security.default_tenant_rate_limit
+} else = limit {
+    limit := input.security.global_rate_limit
+}
+
+# Helpers
+tenant_is_allowed(tenant_id, allowed_list) {
+    count(allowed_list) == 0
+}
+
+tenant_is_allowed(tenant_id, allowed_list) {
+    allowed_list[_] == tenant_id
+}
+
+is_valid_jwt_structure(token) {
+    # Validação básica: 3 partes separadas por '.'
+    parts := split(token, ".")
+    count(parts) == 3
+}
+
+# Helper: Obter JWKS do SPIRE Server via HTTP
+# Usa cache interno do OPA para evitar requests excessivos
+# Retorna JWKS JSON ou undefined se indisponível
+get_spire_jwks := jwks {
+    # Verificar se JWKS foi fornecido via data (testes ou bundle)
+    jwks := data.spire_jwks
+} else := jwks {
+    # Buscar JWKS via HTTP do SPIRE Server
+    jwks_url := input.security.jwks_url
+    jwks_url != null
+
+    response := http.send({
+        "method": "GET",
+        "url": jwks_url,
+        "cache": true,
+        "force_cache": true,
+        "force_cache_duration_seconds": 300,  # Cache de 5 minutos
+        "timeout": "5s",
+        "raise_error": false
+    })
+
+    response.status_code == 200
+    jwks := response.body
+}
+
+# Helper: Validar JWT com verificação de assinatura usando JWKS do SPIRE
+# Modos de operação:
+# 1. Produção: JWKS carregado via http.send do SPIRE Server ou via data.spire_jwks
+# 2. Dev explícito: Fallback sem assinatura APENAS se input.security.jwt_allow_unsigned_fallback == true
+# 3. Fail-closed: Retorna false se JWKS indisponível e fallback não permitido
+is_valid_jwt_with_verification(token) {
+    # Validação básica de estrutura
+    is_valid_jwt_structure(token)
+
+    # Obter configuração de segurança do input
+    issuer := input.security.jwt_issuer
+    audience := input.security.jwt_audience
+
+    # Obter JWKS (via data ou http.send)
+    jwks := get_spire_jwks
+
+    # Verificar assinatura com JWKS
+    # io.jwt.decode_verify retorna [valid, header, payload]
+    # IMPORTANTE: time deve estar em segundos (Unix timestamp), não nanosegundos
+    [valid, header, payload] := io.jwt.decode_verify(
+        token,
+        {
+            "cert": jwks,
+            "iss": issuer,
+            "aud": audience,
+            "time": time.now_ns() / 1000000000  # Converter nanosegundos para segundos
+        }
+    )
+
+    # Validação bem-sucedida se valid == true
+    valid == true
+
+    # Verificar claims obrigatórios (incluindo novos: tenant_id, roles)
+    payload.sub
+    payload.exp
+    payload.iat
+    payload.tenant_id  # Claim obrigatório para multi-tenancy
+    payload.roles      # Claim obrigatório para RBAC
+}
+
+# Fallback EXPLÍCITO: Validar JWT sem verificação de assinatura
+# ATENÇÃO SEGURANÇA: Este fallback só é ativado quando:
+# 1. JWKS não está disponível (nem via data nem via http.send)
+# 2. input.security.jwt_allow_unsigned_fallback == true (opt-in explícito)
+# Em produção, jwt_allow_unsigned_fallback DEVE ser false (default)
+is_valid_jwt_with_verification(token) {
+    # Validação básica de estrutura
+    is_valid_jwt_structure(token)
+
+    # CRÍTICO: Fallback só permitido se explicitamente habilitado
+    input.security.jwt_allow_unsigned_fallback == true
+
+    # Verificar que JWKS realmente não está disponível
+    not get_spire_jwks
+
+    # Decodificar sem verificar assinatura
+    [header, payload, signature] := io.jwt.decode(token)
+
+    # Verificar campos obrigatórios mínimos (estrutura + expiração)
+    payload.sub
+    payload.exp
+    payload.iat
+    payload.tenant_id  # Também exigir claims de multi-tenancy
+    payload.roles      # Também exigir claims de RBAC
+
+    # Validar expiração manualmente
+    current_time := time.now_ns() / 1000000000
+    payload.exp > current_time
+}
+
+# Helper: Verificar se audience corresponde
+audience_matches(aud, expected) {
+    # aud é string
+    is_string(aud)
+    aud == expected
+}
+
+audience_matches(aud, expected) {
+    # aud é array
+    is_array(aud)
+    aud[_] == expected
+}
+
+has_capability_permission(roles, capability) {
+    # Mapeamento simplificado: developer pode code_generation/testing, admin pode tudo
+    roles[_] == "admin"
+}
+
+has_capability_permission(roles, capability) {
+    roles[_] == "developer"
+    capability_allowed_for_developer(capability)
+}
+
+capability_allowed_for_developer(cap) {
+    cap == "code_generation"
+}
+
+capability_allowed_for_developer(cap) {
+    cap == "testing"
+}
+
+# Security context para auditoria
+security_context := {
+    "tenant_id": input.resource.tenant_id,
+    "user_id": input.context.user_id,
+    "authenticated": is_authenticated,
+    "authorized": is_authorized,
+    "timestamp": input.context.current_time
+}
+
+is_authenticated {
+    input.context.jwt_token != null
+    is_valid_jwt_structure(input.context.jwt_token)
+}
+
+is_authorized {
+    count([v | v := violations[_]; v.rule == "insufficient_permissions"]) == 0
+}

--- a/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/sla_enforcement.rego
+++ b/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/sla_enforcement.rego
@@ -1,0 +1,260 @@
+package neuralhive.orchestrator.sla_enforcement
+
+# Mapeamento de QoS por risk_band
+qos_requirements := {
+    "critical": {
+        "delivery_mode": "EXACTLY_ONCE",
+        "consistency": "STRONG"
+    },
+    "high": {
+        "delivery_mode": "EXACTLY_ONCE",
+        "consistency": "STRONG"
+    },
+    "medium": {
+        "delivery_mode": "AT_LEAST_ONCE",
+        "consistency": ["STRONG", "EVENTUAL"]
+    },
+    "low": {
+        "delivery_mode": ["AT_LEAST_ONCE", "AT_MOST_ONCE"],
+        "consistency": ["STRONG", "EVENTUAL", "WEAK"]
+    }
+}
+
+# Mapeamento de priority por risk_band
+priority_requirements := {
+    "critical": ["CRITICAL"],
+    "high": ["CRITICAL", "HIGH"],
+    "medium": ["CRITICAL", "HIGH", "NORMAL"],
+    "low": ["CRITICAL", "HIGH", "NORMAL", "LOW"]
+}
+
+# Resultado principal
+result := {
+    "allow": allow,
+    "violations": violations,
+    "warnings": warnings
+}
+
+# Allow se não houver violações
+default allow := false
+allow {
+    count(violations) == 0
+}
+
+# Coletar todas as violações
+violations[violation] {
+    violation := deadline_in_past
+}
+
+violations[violation] {
+    violation := deadline_too_far
+}
+
+violations[violation] {
+    violation := qos_mismatch_risk_band
+}
+
+violations[violation] {
+    violation := priority_mismatch_risk_band
+}
+
+violations[violation] {
+    violation := timeout_insufficient
+}
+
+# Coletar warnings
+warnings[warning] {
+    warning := deadline_approaching_threshold
+}
+
+# Regra 1: Deadline no passado
+deadline_in_past := violation {
+    ticket := input.resource
+    deadline := ticket.sla.deadline
+    current_time := input.context.current_time
+
+    deadline < current_time
+
+    violation := {
+        "policy": "sla_enforcement",
+        "rule": "deadline_in_past",
+        "severity": "critical",
+        "field": "sla.deadline",
+        "msg": sprintf("Deadline %v está no passado (current_time=%v)", [deadline, current_time]),
+        "expected": sprintf(">%v", [current_time]),
+        "actual": deadline
+    }
+}
+
+# Regra 2: Deadline muito distante (>7 dias)
+deadline_too_far := violation {
+    ticket := input.resource
+    deadline := ticket.sla.deadline
+    current_time := input.context.current_time
+
+    # 7 dias em milissegundos
+    seven_days_ms := 7 * 24 * 60 * 60 * 1000
+    max_deadline := current_time + seven_days_ms
+
+    deadline > max_deadline
+
+    violation := {
+        "policy": "sla_enforcement",
+        "rule": "deadline_too_far",
+        "severity": "medium",
+        "field": "sla.deadline",
+        "msg": sprintf("Deadline está muito distante (>7 dias): %v", [deadline]),
+        "expected": sprintf("<=%v", [max_deadline]),
+        "actual": deadline
+    }
+}
+
+# Regra 3: QoS não alinhado com risk_band
+qos_mismatch_risk_band := violation {
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    qos := ticket.qos
+
+    # Para critical e high, validar delivery_mode exato
+    risk_band == "critical"
+    required_delivery := qos_requirements[risk_band].delivery_mode
+    qos.delivery_mode != required_delivery
+
+    violation := {
+        "policy": "sla_enforcement",
+        "rule": "qos_mismatch_risk_band",
+        "severity": "critical",
+        "field": "qos.delivery_mode",
+        "msg": sprintf("Risk_band=%v requer delivery_mode=%v, encontrado %v", [risk_band, required_delivery, qos.delivery_mode]),
+        "expected": required_delivery,
+        "actual": qos.delivery_mode
+    }
+}
+
+qos_mismatch_risk_band := violation {
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    qos := ticket.qos
+
+    risk_band == "high"
+    required_delivery := qos_requirements[risk_band].delivery_mode
+    qos.delivery_mode != required_delivery
+
+    violation := {
+        "policy": "sla_enforcement",
+        "rule": "qos_mismatch_risk_band",
+        "severity": "high",
+        "field": "qos.delivery_mode",
+        "msg": sprintf("Risk_band=%v requer delivery_mode=%v, encontrado %v", [risk_band, required_delivery, qos.delivery_mode]),
+        "expected": required_delivery,
+        "actual": qos.delivery_mode
+    }
+}
+
+qos_mismatch_risk_band := violation {
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    qos := ticket.qos
+
+    # Para critical e high, validar consistency
+    risk_band == "critical"
+    required_consistency := qos_requirements[risk_band].consistency
+    qos.consistency != required_consistency
+
+    violation := {
+        "policy": "sla_enforcement",
+        "rule": "qos_mismatch_risk_band",
+        "severity": "critical",
+        "field": "qos.consistency",
+        "msg": sprintf("Risk_band=%v requer consistency=%v, encontrado %v", [risk_band, required_consistency, qos.consistency]),
+        "expected": required_consistency,
+        "actual": qos.consistency
+    }
+}
+
+qos_mismatch_risk_band := violation {
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    qos := ticket.qos
+
+    risk_band == "high"
+    required_consistency := qos_requirements[risk_band].consistency
+    qos.consistency != required_consistency
+
+    violation := {
+        "policy": "sla_enforcement",
+        "rule": "qos_mismatch_risk_band",
+        "severity": "high",
+        "field": "qos.consistency",
+        "msg": sprintf("Risk_band=%v requer consistency=%v, encontrado %v", [risk_band, required_consistency, qos.consistency]),
+        "expected": required_consistency,
+        "actual": qos.consistency
+    }
+}
+
+# Regra 4: Priority não alinhada com risk_band
+priority_mismatch_risk_band := violation {
+    ticket := input.resource
+    risk_band := ticket.risk_band
+    priority := ticket.priority
+
+    allowed_priorities := priority_requirements[risk_band]
+    not priority_is_allowed(priority, allowed_priorities)
+
+    violation := {
+        "policy": "sla_enforcement",
+        "rule": "priority_mismatch_risk_band",
+        "severity": "medium",
+        "field": "priority",
+        "msg": sprintf("Priority=%v não permitida para risk_band=%v (permitidas: %v)", [priority, risk_band, allowed_priorities]),
+        "expected": allowed_priorities,
+        "actual": priority
+    }
+}
+
+# Regra 5: Timeout insuficiente
+timeout_insufficient := violation {
+    ticket := input.resource
+    timeout_ms := ticket.sla.timeout_ms
+    estimated_ms := ticket.estimated_duration_ms
+
+    # Timeout deve ser >= estimated_duration * 1.5
+    min_timeout := estimated_ms * 1.5
+    timeout_ms < min_timeout
+
+    violation := {
+        "policy": "sla_enforcement",
+        "rule": "timeout_insufficient",
+        "severity": "high",
+        "field": "sla.timeout_ms",
+        "msg": sprintf("Timeout de %vms insuficiente para estimated_duration de %vms (requer >=1.5x = %vms)", [timeout_ms, estimated_ms, min_timeout]),
+        "expected": sprintf(">=%v", [min_timeout]),
+        "actual": timeout_ms
+    }
+}
+
+# Warning: Deadline se aproximando
+deadline_approaching_threshold := warning {
+    ticket := input.resource
+    deadline := ticket.sla.deadline
+    current_time := input.context.current_time
+
+    time_remaining := deadline - current_time
+    timeout_ms := ticket.sla.timeout_ms
+
+    # Warning se <20% do tempo restante
+    threshold := timeout_ms * 0.2
+    time_remaining < threshold
+    time_remaining > 0  # Não duplicar com deadline_in_past
+
+    warning := {
+        "policy": "sla_enforcement",
+        "rule": "deadline_approaching_threshold",
+        "msg": sprintf("Deadline se aproximando: restam apenas %vms (<20%% do timeout)", [time_remaining])
+    }
+}
+
+# Helper: Verificar se priority está permitida
+priority_is_allowed(priority, allowed_list) {
+    allowed_list[_] == priority
+}


### PR DESCRIPTION
## Causa

`opa-policies` ConfigMap deployava com 4/5 ficheiros .rego em 0 bytes, causando OPA crashloop:

```
bundle /policies: ... feature_flags.rego:0: rego_parse_error: empty module
```

`helm-charts/orchestrator-dynamic/templates/opa-configmap.yaml` usa `.Files.Get "policies/rego/orchestrator/X.rego"`, mas o `.Files.Get` do Helm **só lê ficheiros dentro do chart directory**. Os `.rego` viviam em `policies/rego/orchestrator/` (raíz do repo, fora do chart) → Helm devolvia string vazia silenciosamente.

## Fix

Cópia dos 5 `.rego` para `helm-charts/orchestrator-dynamic/policies/rego/orchestrator/`.

## Sync

Os 2 paths devem manter-se sincronizados:
- `policies/rego/orchestrator/` (source, usado pelo orchestrator-dynamic em dev local)
- `helm-charts/orchestrator-dynamic/policies/rego/orchestrator/` (cópia para Helm packaging)

Sugestão para próxima iteração: adicionar pre-commit hook ou Makefile target `sync-opa-policies` para evitar drift.