### PR TITLE
fix(opa): add default warnings to security_constraints.rego

### DIFF
--- a/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/security_constraints.rego
+++ b/helm-charts/orchestrator-dynamic/policies/rego/orchestrator/security_constraints.rego
@@ -1,5 +1,8 @@
 package neuralhive.orchestrator.security_constraints
 
+# Default values para evitar rego_unsafe_var_error quando rules não disparam
+default warnings := []
+
 # Resultado principal
 result := {
     "allow": allow,

--- a/policies/rego/orchestrator/security_constraints.rego
+++ b/policies/rego/orchestrator/security_constraints.rego
@@ -1,5 +1,8 @@
 package neuralhive.orchestrator.security_constraints
 
+# Default values para evitar rego_unsafe_var_error quando rules não disparam
+default warnings := []
+
 # Resultado principal
 result := {
     "allow": allow,


### PR DESCRIPTION
OPA falhava com `rego_unsafe_var_error: var warnings is unsafe` em security_constraints.rego:4 — o objecto `result` referencia `warnings` mas nunca é definido. Fix: `default warnings := []`. Replica no helm chart copy.