### PR TITLE
fix(dockerfiles): copy neural_hive_security in execution-ticket-service + consensus-engine

### DIFF
--- a/services/consensus-engine/Dockerfile
+++ b/services/consensus-engine/Dockerfile
@@ -4,15 +4,17 @@ FROM ${REGISTRY}/neural-hive-mind/python-grpc-base:1.0.7 AS builder
 
 WORKDIR /app
 
-# Copy internal library for installation
+# Copy internal libraries for installation
 COPY libraries/python/neural_hive_domain /tmp/neural_hive_domain
+COPY libraries/python/neural_hive_security /tmp/neural_hive_security
 
-# Instalar dependências (base + service) e biblioteca interna
+# Instalar dependências (base + service) e bibliotecas internas
 COPY requirements-base.txt ./requirements-base.txt
 COPY services/consensus-engine/requirements.txt ./requirements-service.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
     pip install --no-cache-dir --user /tmp/neural_hive_domain && \
+    pip install --no-cache-dir --user /tmp/neural_hive_security && \
     pip install --no-cache-dir --user -r requirements.txt && \
     python -m uvicorn --version && \
     echo "✓ uvicorn runtime verification passed"

--- a/services/execution-ticket-service/Dockerfile
+++ b/services/execution-ticket-service/Dockerfile
@@ -16,8 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copiar requirements (base + service) e instalar dependências Python diretamente no sistema
 COPY requirements-base.txt ./requirements-base.txt
 COPY services/execution-ticket-service/requirements.txt ./requirements-service.txt
+COPY libraries/python/neural_hive_security /tmp/neural_hive_security
 RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir /tmp/neural_hive_security && \
+    pip install --no-cache-dir -r requirements.txt && \
+    rm -rf /tmp/neural_hive_security
 
 # Copiar código fonte
 COPY services/execution-ticket-service/src/ ./src/


### PR DESCRIPTION
Os 2 serviços importam `neural_hive_security.cors` no source mas o Dockerfile não copia a lib — `ModuleNotFoundError: No module named 'neural_hive_security'` no startup.

Fix segue o padrão de architect-agent/doc-ingestion.

(Nota: outros 11 serviços têm o mesmo gap mas funcionam por terem o import em try/except. Esta PR foca nos 2 críticos que crash diretamente.)