### PR TITLE
chore: ml-inference-api deploy readiness + nlu-service proto cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ services/code-forge/scripts/test-e2e-*.sh
 # Proto gerado
 libraries/python/neural_hive_agent_sdk/proto/
 
+# Proto duplicates accidentally generated at nlu-service root
+# (canonical pb2 files live in services/nlu-service/src/proto/)
+services/nlu-service/*_pb2.py
+services/nlu-service/*_pb2_grpc.py
+
 # Tests locais
 tests/test-approval-flow.sh
 

--- a/k8s/ml-inference-api-deployment.yaml
+++ b/k8s/ml-inference-api-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,8 +13,10 @@ data:
   # Inference cache
   CACHE_TTL_SECONDS: "3600"
   # External service endpoints (in-cluster DNS)
-  REDIS_URL: "redis://neural-hive-cache.redis-cluster.svc.cluster.local:6379/0"
-  KAFKA_BOOTSTRAP_SERVERS: "neural-hive-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092"
+  REDIS_URL: >-
+    redis://neural-hive-cache.redis-cluster.svc.cluster.local:6379/0
+  KAFKA_BOOTSTRAP_SERVERS: >-
+    neural-hive-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/ml-inference-api-deployment.yaml
+++ b/k8s/ml-inference-api-deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ml-inference-api-config
+  namespace: neural-hive
+data:
+  LOG_LEVEL: "INFO"
+  ENVIRONMENT: "kubernetes"
+  NEURAL_HIVE_SERVICE_NAME: "ml-inference-api"
+  NEURAL_HIVE_COMPONENT: "ml-inference"
+  NEURAL_HIVE_LAYER: "ml-pipeline"
+  # Inference cache
+  CACHE_TTL_SECONDS: "3600"
+  # External service endpoints (in-cluster DNS)
+  REDIS_URL: "redis://neural-hive-cache.redis-cluster.svc.cluster.local:6379/0"
+  KAFKA_BOOTSTRAP_SERVERS: "neural-hive-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-inference-api
+  namespace: neural-hive
+  labels:
+    app: ml-inference-api
+    component: ml-inference
+    neuralhive/layer: ml-pipeline
+    neuralhive/phase: phase4
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ml-inference-api
+  template:
+    metadata:
+      labels:
+        app: ml-inference-api
+        app.kubernetes.io/name: ml-inference-api
+        app.kubernetes.io/instance: ml-inference-api
+        component: ml-inference
+    spec:
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: ml-inference-api
+          image: ghcr.io/albinojimy/neural-hive-mind/ml-inference-api:main
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8020
+              name: http
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: ml-inference-api-config
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8020
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8020
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-inference-api
+  namespace: neural-hive
+  labels:
+    app: ml-inference-api
+    component: ml-inference
+spec:
+  selector:
+    app: ml-inference-api
+  ports:
+    - name: http
+      port: 8020
+      targetPort: 8020
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ml-inference-api-hpa
+  namespace: neural-hive
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ml-inference-api
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/services/ml-inference-api/Dockerfile
+++ b/services/ml-inference-api/Dockerfile
@@ -1,0 +1,54 @@
+# Single stage build for ML Inference API using observability base
+ARG REGISTRY=ghcr.io/albinojimy
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.7
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    make \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements (base + service) and install dependencies into system Python
+COPY requirements-base.txt ./requirements-base.txt
+COPY services/ml-inference-api/requirements.txt ./requirements-service.txt
+RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Create non-root user
+RUN useradd -m -u 1000 app
+
+# Copy application code (main.py lives at service root, modules in src/)
+COPY services/ml-inference-api/main.py ./main.py
+COPY services/ml-inference-api/src/ ./src/
+
+# Fix ownership and permissions for non-root user
+RUN chown -R app:app /app && chmod -R a+r /app
+
+# Update PYTHONPATH
+ENV PYTHONPATH=/app \
+    PYTHONUNBUFFERED=1
+
+# Switch to non-root user
+USER app
+
+# Expose port
+EXPOSE 8020
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8020/health').read()"
+
+# Labels
+LABEL maintainer="Neural Hive-Mind Team <team@neural-hive-mind.org>" \
+      version="0.2.0" \
+      description="ML Inference API - Model prediction service with caching and Kafka integration" \
+      neural-hive.io/component="ml-inference-api" \
+      neural-hive.io/layer="ml-pipeline" \
+      neural-hive.io/domain="inference"
+
+# Start application with uvicorn (single worker for local development)
+CMD ["sh", "-c", "python -m uvicorn main:app --host 0.0.0.0 --port 8020 --workers 1"]

--- a/services/ml-inference-api/main.py
+++ b/services/ml-inference-api/main.py
@@ -1,6 +1,7 @@
 """ML Inference API - API de Inferência de Modelos ML."""
 
 import asyncio
+import os
 import signal
 
 import structlog
@@ -86,11 +87,14 @@ async def main():
     """Ponto de entrada principal."""
     global inference_service, kafka_consumer, kafka_producer, consumer_task
 
+    cache_ttl = int(os.getenv("CACHE_TTL_SECONDS", "3600"))
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    kafka_bootstrap = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+
     # Inicializar serviço de inferência
-    inference_service = InferenceService(cache_ttl_seconds=3600)
+    inference_service = InferenceService(cache_ttl_seconds=cache_ttl)
 
     # Conectar ao Redis se disponível
-    redis_url = "redis://localhost:6379/0"
     try:
         await inference_service.connect_redis(redis_url)
     except Exception as e:
@@ -100,12 +104,14 @@ async def main():
     app = create_app(inference_service)
 
     # Inicializar producer Kafka
-    kafka_producer = InferenceResultProducer()
+    kafka_producer = InferenceResultProducer(bootstrap_servers=kafka_bootstrap)
     await kafka_producer.start()
 
     # Inicializar consumer Kafka
     kafka_consumer = InferenceRequestConsumer(
-        inference_service=inference_service, producer=kafka_producer
+        bootstrap_servers=kafka_bootstrap,
+        inference_service=inference_service,
+        producer=kafka_producer,
     )
 
     # Setup signal handlers

--- a/services/ml-inference-api/requirements.txt
+++ b/services/ml-inference-api/requirements.txt
@@ -1,18 +1,6 @@
-# Requirements para ML Inference API
+# Dependências base consolidadas para Neural-Hive-Mind
+-r ../../requirements-base.txt
 
-# Web Framework
-fastapi==0.109.0
-uvicorn[standard]==0.24.0
-
-# Kafka
-aiokafka==0.9.0
-
-# Redis
-redis[hiredis]==5.0.1
-
-# Observability
-structlog==23.2.0
-neural-hive-observability==1.0.0
-
-# Pydantic
-pydantic==2.6.0
+# Service-specific dependencies
+# (todas as deps actuais — FastAPI, uvicorn, aiokafka, redis, structlog, pydantic —
+#  já estão no requirements-base.txt com versões alinhadas ao padrão da plataforma)

--- a/services/nlu-service/Makefile
+++ b/services/nlu-service/Makefile
@@ -1,0 +1,26 @@
+.PHONY: generate-protos clean-protos help
+
+PROTO_DIR := src/proto
+PROTO_FILES := $(wildcard $(PROTO_DIR)/*.proto)
+
+help:
+	@echo "nlu-service — proto management"
+	@echo ""
+	@echo "Targets:"
+	@echo "  generate-protos   Regenerate *_pb2.py and *_pb2_grpc.py from .proto files"
+	@echo "  clean-protos      Remove generated pb2 files (forces regeneration on next run)"
+	@echo ""
+	@echo "Generated files live in $(PROTO_DIR)/ and are tracked in git."
+
+generate-protos:
+	@echo "Generating protobuf bindings from $(PROTO_FILES)..."
+	python -m grpc_tools.protoc \
+		-I$(PROTO_DIR) \
+		--python_out=$(PROTO_DIR) \
+		--grpc_python_out=$(PROTO_DIR) \
+		$(PROTO_FILES)
+	@echo "Done. Generated files in $(PROTO_DIR)/"
+
+clean-protos:
+	@rm -f $(PROTO_DIR)/*_pb2.py $(PROTO_DIR)/*_pb2_grpc.py
+	@echo "Removed generated pb2 files."


### PR DESCRIPTION
## Summary

- **ml-inference-api**: Fecha os 3 bloqueadores estruturais identificados na análise de completude da Fase 4 — adiciona `Dockerfile` (padrão `python-observability-base:1.2.7`), manifest K8s (`ConfigMap` + `Deployment` + `Service` + `HPA` no namespace `neural-hive`) e passa `main.py` a ler `REDIS_URL` / `KAFKA_BOOTSTRAP_SERVERS` / `CACHE_TTL_SECONDS` via env vars. `requirements.txt` substituído por `-r ../../requirements-base.txt` (resolve 6 conflitos de versão).
- **nlu-service**: Limpa duplicados acidentais de protobuf na raiz do serviço (`*_pb2.py` / `*_pb2_grpc.py`) — os canónicos vivem em `src/proto/` e ficam tracked. Adiciona `Makefile` com targets `generate-protos` e `clean-protos`.

⚠️ Os modelos ML em `ml-inference-api/src/services/inference_service.py` continuam **mocked** (`asyncio.sleep`). Substituir por `joblib.load` / ONNX é trabalho separado (≈1-2 dias) e fica fora deste lote de deploy readiness.

## Test plan

- [x] `python3 -m py_compile services/ml-inference-api/main.py` — passa
- [x] `kubectl apply --dry-run=client -f k8s/ml-inference-api-deployment.yaml` — 4 recursos válidos (ConfigMap + Deployment + Service + HPA)
- [x] `docker build -f services/ml-inference-api/Dockerfile` parse OK (build completo requer auth no GHCR — feito pelo CI)
- [x] Endpoints DNS validados via `kubectl get svc -A` (Redis em namespace `redis-cluster`, Kafka em `kafka`)
- [ ] CI: `Build and Push to GHCR` constrói a imagem `ghcr.io/albinojimy/neural-hive-mind/ml-inference-api:main`
- [ ] CI: `Test Coverage Enforcement` e `Python Linting` passam
- [ ] Após merge: `kubectl apply -f k8s/ml-inference-api-deployment.yaml` no cluster e verificar pod healthy
- [ ] Verificar logs do pod para confirmar leitura correcta das env vars (`REDIS_URL`, `KAFKA_BOOTSTRAP_SERVERS`)

ℹ️ Os 2 workflows que falham em 0s (`.github/workflows/test-coverage.yml` e `online-learning-pipeline.yml`) têm um problema estrutural no ficheiro YAML que afecta todos os pushes recentes (PR #66, #67, #68) — **não introduzido por estes commits**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)