### PR TITLE
debug(consensus-engine): log silent ImportError in clients/__init__.py

### DIFF
--- a/services/consensus-engine/src/clients/__init__.py
+++ b/services/consensus-engine/src/clients/__init__.py
@@ -9,7 +9,12 @@ try:
     from .specialists_grpc_client import SpecialistsGrpcClient
 
     _grcp_available = True
-except ImportError:
+except ImportError as _err:
+    import logging
+    logging.getLogger(__name__).warning(
+        "Optional gRPC clients unavailable: %s: %s",
+        type(_err).__name__, _err,
+    )
     _grcp_available = False
 
 __all__ = [


### PR DESCRIPTION
src/clients/__init__.py suprimia silenciosamente ImportError dos 3 gRPC clients, causando crash genérico em main.py. Adiciona log.warning antes do fallback para revelar erro real (módulo a faltar, etc).