### PR TITLE
chore(settings): fix obsolete kafka-cluster default in Python Settings

### DIFF
--- a/services/mcp-tool-catalog/src/config/settings.py
+++ b/services/mcp-tool-catalog/src/config/settings.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
 
     # Kafka Configuration
     KAFKA_BOOTSTRAP_SERVERS: str = Field(
-        default="kafka-cluster-kafka-bootstrap:9092", description="Kafka bootstrap servers"
+        default="neural-hive-kafka-kafka-bootstrap:9092", description="Kafka bootstrap servers"
     )
     KAFKA_TOOL_SELECTION_REQUEST_TOPIC: str = "mcp.tool.selection.requests"
     KAFKA_TOOL_SELECTION_RESPONSE_TOPIC: str = "mcp.tool.selection.responses"

--- a/services/memory-layer-api/src/config/settings.py
+++ b/services/memory-layer-api/src/config/settings.py
@@ -76,7 +76,7 @@ class Settings(BaseSettings):
 
     # Kafka (Real-time Sync)
     kafka_bootstrap_servers: str = Field(
-        default="kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092",
+        default="neural-hive-kafka-kafka-bootstrap.kafka.svc.cluster.local:9092",
         description="Kafka bootstrap servers",
     )
     kafka_sync_topic: str = Field(


### PR DESCRIPTION
## Summary

Atualiza os defaults Pydantic Settings em 2 services para usar o nome canónico do Strimzi Kafka cluster (`neural-hive-kafka`) em vez do antigo (`kafka-cluster`).

Complementa PR #73 (Helm chart fix) — agora o defaults em código também estão alinhados.

## Mudanças

- `services/mcp-tool-catalog/src/config/settings.py:32` — Kafka default fix
- `services/memory-layer-api/src/config/settings.py:79` — Kafka default fix

## Why It Matters

Em produção, env var `KAFKA_BOOTSTRAP_SERVERS` é injectada via ConfigMap. Mas se falhar (e.g. testes locais sem .env, debug ad-hoc, novos environments), o default actual apontaria para um service inexistente.

## Test plan

- [x] `grep -rn "kafka-cluster-kafka-bootstrap" services/{mcp-tool-catalog,memory-layer-api}/src/config/` → 0 matches
- [ ] CI: Python Linting passa
- [ ] CI: Unit Tests passam

🤖 Generated with [Claude Code](https://claude.com/claude-code)