### PR TITLE
chore(prometheus): remove dead kafka-cluster scrape job

### DIFF
--- a/helm-charts/prometheus-stack/templates/prometheus.yaml
+++ b/helm-charts/prometheus-stack/templates/prometheus.yaml
@@ -249,16 +249,13 @@ data:
         target_label: service_name
 
     # Kafka Cluster
-    - job_name: 'kafka-cluster'
-      static_configs:
-      - targets:
-        - 'kafka-0.kafka.svc.cluster.local:9308'
-        - 'kafka-1.kafka.svc.cluster.local:9308'
-        - 'kafka-2.kafka.svc.cluster.local:9308'
-      scrape_interval: 30s
-      static_labels:
-        neural_hive_component: kafka
-        neural_hive_layer: orquestracao
+    # NOTE: Removed dead scrape job — targets `kafka-{0,1,2}.kafka.svc.cluster.local:9308`
+    # nunca existiram. Strimzi cluster real é `neural-hive-kafka-broker-0/2` (KafkaNodePool
+    # broker [0,2] + controller [1,3,4]) e não tem JMX-Prometheus exporter configurado
+    # (Kafka CR sem `metricsConfig`). Para activar métricas Kafka no futuro:
+    #   1. Criar ConfigMap kafka-metrics com regras JMX
+    #   2. Patch Kafka CR + KafkaNodePools com `metricsConfig.valueFrom.configMapKeyRef`
+    #   3. Criar PodMonitor apontando para porta 9404 (Strimzi expõe automaticamente)
 
     # Kubernetes API Server
     - job_name: 'kubernetes-apiservers'


### PR DESCRIPTION
## Summary

Remove o scrape job `kafka-cluster` do Prometheus config — targets nunca existiram no cluster e o job tem estado "always failing" silenciosamente há meses.

## Drift Detalhado

| Item | Config Antiga | Realidade Cluster |
|---|---|---|
| Cluster name | `kafka-cluster` | `neural-hive-kafka` (Strimzi CR) |
| Broker pods | `kafka-{0,1,2}` | `neural-hive-kafka-broker-{0,2}` (KafkaNodePool ids [0,2]) |
| Controllers | n/a | `neural-hive-kafka-controller-{1,3,4}` (KafkaNodePool ids [1,3,4]) |
| Port 9308 (kafka-exporter) | esperado | **inexistente** (nenhum service expõe) |
| Port 9404 (Strimzi JMX) | n/a | **inexistente** (Kafka CR sem `metricsConfig`) |

## Why Remove vs Fix

Strimzi cluster nunca foi configurado com `metricsConfig` — fixar requer:
1. ConfigMap com regras JMX-Prometheus
2. Patch ao Kafka CR + ambos os KafkaNodePools
3. Criar PodMonitor

Trabalho não trivial + rolling restart dos brokers (broker-0 acabou de estabilizar após incidente de mount stale de 7h hoje). **Remover é seguro e reversível** (git revert) — quando alguém quiser activar métricas Kafka, pode fazê-lo correctamente via PR separado.

Adicionei comentário no ficheiro com instruções para reactivação futura.

## Test plan

- [x] Diff confirma apenas remoção do job `kafka-cluster` (linhas 252-261)
- [x] Comentário com instruções de reactivação adicionado em-place
- [ ] CI: Helm Lint passa (Helm template render OK)
- [ ] Após merge: `helm upgrade prometheus-stack` aplica config sem o job — Prometheus reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)