### PR TITLE
fix(helm/fluxo-g-dashboard): disable Service Link env injection

### DIFF
--- a/helm-charts/fluxo-g-dashboard/templates/deployment.yaml
+++ b/helm-charts/fluxo-g-dashboard/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "fluxo-g-dashboard.fullname" . }}
+      enableServiceLinks: false
       containers:
       - name: {{ .Chart.Name }}
         securityContext:


### PR DESCRIPTION
## Summary

Corrige `fluxo-g-dashboard` em CrashLoopBackOff (298 restarts em 25h) por conflito de variável de ambiente.

## Causa raiz

- `Service` chamado `fluxo-g-dashboard` (porta 8021) **+** Deployment com o mesmo nome
- K8s injecta automaticamente `FLUXO_G_DASHBOARD_PORT=tcp://10.100.55.127:8021` (legacy Docker-link envs)
- `pydantic_settings.Settings` em `services/fluxo-g-dashboard/src/config/settings.py` usa `env_prefix="FLUXO_G_DASHBOARD_"` e tem campo `port: int = 8021`
- Pydantic tenta parsear `tcp://10.100.55.127:8021` como `int` → `ValidationError` → crash no boot

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
port
  Input should be a valid integer, unable to parse string as an integer
  [type=int_parsing, input_value='tcp://10.100.55.127:8021', input_type=str]
```

## Solução

`enableServiceLinks: false` no pod spec — desactiva injecção legacy de envs `<SVC>_PORT`, `<SVC>_SERVICE_HOST`, etc. DNS service discovery continua funcional.

## Validação

Patch aplicado directamente no cluster:
- ✅ Replica nova (`svltv`) Running 2/2 há 6+ min
- ✅ Logs limpos, sem mais ValidationError

## Test plan

- [x] Patch directo no cluster valida o fix
- [ ] CI/CD deploya rev nova com `enableServiceLinks: false`
- [ ] `kubectl get pods -n neural-hive -l app=fluxo-g-dashboard` → todas Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)