### PR TITLE
fix(sla-management-system): install neural_hive_security in image

### DIFF
--- a/services/sla-management-system/Dockerfile
+++ b/services/sla-management-system/Dockerfile
@@ -11,11 +11,15 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Copy local libraries first
+COPY libraries/python/neural_hive_security /tmp/neural_hive_security
+
 # Copy requirements (base + service) and install dependencies to user directory
 COPY requirements-base.txt ./requirements-base.txt
 COPY services/sla-management-system/requirements.txt ./requirements-service.txt
 RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirements-service.txt > requirements.txt && \
     pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --user /tmp/neural_hive_security && \
     pip install --no-cache-dir --user -r requirements.txt
 
 # Stage 2: Runtime - use same base to keep neural_hive_observability


### PR DESCRIPTION
## Summary

Corrige `sla-management-system` em CrashLoopBackOff (237 restarts em 23h).

## Causa raiz

`services/sla-management-system/src/config/settings.py:11`:
```python
from neural_hive_security.cors import CORSConfig
```

A lib `neural_hive_security` existe em `libraries/python/neural_hive_security/`, mas o Dockerfile não a copiava nem instalava, ao contrário do padrão usado por `queen-agent`, `consensus-engine`, `guard-agents`, `orchestrator-dynamic`, etc.

```
ModuleNotFoundError: No module named 'neural_hive_security'
```

## Solução

Alinha o Dockerfile com o padrão `queen-agent`:

```dockerfile
COPY libraries/python/neural_hive_security /tmp/neural_hive_security
...
pip install --no-cache-dir --user /tmp/neural_hive_security && \
pip install --no-cache-dir --user -r requirements.txt
```

## Test plan

- [ ] CI build da imagem `sla-management-system` inclui `neural_hive_security`
- [ ] Após deploy: `kubectl logs -n neural-hive deploy/sla-management-system` sem `ModuleNotFoundError`
- [ ] Pod `sla-management-system` Running 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)