### PR TITLE
fix(helm/memory-layer-api): inject NEO4J_* env in 3 CronJobs

### DIFF
--- a/helm-charts/memory-layer-api/templates/cronjob-quality.yaml
+++ b/helm-charts/memory-layer-api/templates/cronjob-quality.yaml
@@ -57,6 +57,26 @@ spec:
               value: {{ .Values.config.mongodb.database | quote }}
             - name: MONGODB_QUALITY_COLLECTION
               value: {{ .Values.config.mongodb.qualityCollection | quote }}
+            - name: NEO4J_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_uri
+            - name: NEO4J_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_user
+            - name: NEO4J_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-secrets
+                  key: neo4j_password
+            - name: NEO4J_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_database
             - name: OTEL_ENDPOINT
               value: {{ .Values.config.otel.endpoint | quote }}
             {{- with .Values.securityContext }}

--- a/helm-charts/memory-layer-api/templates/cronjob-retention.yaml
+++ b/helm-charts/memory-layer-api/templates/cronjob-retention.yaml
@@ -68,6 +68,26 @@ spec:
               value: {{ .Values.config.clickhouse.host | quote }}
             - name: RETENTION_DRY_RUN
               value: {{ .Values.retention.dryRun | quote }}
+            - name: NEO4J_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_uri
+            - name: NEO4J_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_user
+            - name: NEO4J_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-secrets
+                  key: neo4j_password
+            - name: NEO4J_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_database
             - name: OTEL_ENDPOINT
               value: {{ .Values.config.otel.endpoint | quote }}
             {{- with .Values.securityContext }}

--- a/helm-charts/memory-layer-api/templates/cronjob-sync.yaml
+++ b/helm-charts/memory-layer-api/templates/cronjob-sync.yaml
@@ -69,6 +69,26 @@ spec:
               value: {{ .Values.sync.batchSize | quote }}
             - name: SYNC_LOOKBACK_HOURS
               value: {{ .Values.sync.lookbackHours | quote }}
+            - name: NEO4J_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_uri
+            - name: NEO4J_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_user
+            - name: NEO4J_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-secrets
+                  key: neo4j_password
+            - name: NEO4J_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "memory-layer-api.fullname" . }}-config
+                  key: neo4j_database
             - name: OTEL_ENDPOINT
               value: {{ .Values.config.otel.endpoint | quote }}
             {{- with .Values.securityContext }}


### PR DESCRIPTION
## Summary

Corrige os 3 CronJobs do `memory-layer-api` em `CrashLoopBackOff` por falta de envs NEO4J.

## Causa raiz

Os 3 jobs (`check_data_quality`, `enforce_retention`, `sync_mongodb_to_clickhouse`) instanciam `Settings()` que em `services/memory-layer-api/src/config/settings.py` declara:

```python
neo4j_password: str = Field(description="Neo4j password (OBRIGATÓRIO)")
```

Os 3 templates CronJob só injectavam MONGODB/REDIS/CLICKHOUSE — sem NEO4J. Resultado:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
neo4j_password
  Field required [type=missing, ...]
```

Pod `memory-layer-api-data-quality-check-29643360-bvck6` com 54 restarts em 4h18m.

## Solução

Adiciona NEO4J_URI/USER/PASSWORD/DATABASE aos 3 CronJobs, com a mesma origem do deployment principal:
- `*-config` ConfigMap para `neo4j_uri`, `neo4j_user`, `neo4j_database`
- `*-secrets` Secret para `neo4j_password`

## Test plan

- [x] `helm template` renderiza 4 ocorrências de `NEO4J_PASSWORD` (1 deployment + 3 cronjobs)
- [ ] CI/CD aplica → próximo trigger do CronJob completa com `Completed`
- [ ] Histórico de jobs sem novos `0/1` failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)