### PR TITLE
fix(ci): bump neural_hive_observability requires-python to >=3.9

### DIFF
--- a/libraries/python/neural_hive_observability/pyproject.toml
+++ b/libraries/python/neural_hive_observability/pyproject.toml
@@ -7,7 +7,7 @@ name = "neural-hive-observability"
 version = "2.1.1"
 description = "Biblioteca de observabilidade padronizada para Neural Hive-Mind"
 readme = {text = "Biblioteca Python que facilita instrumentação OpenTelemetry consistente entre serviços do Neural Hive-Mind com tracing, métricas e logging estruturado.", content-type = "text/plain"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 authors = [
     {name = "Neural Hive-Mind Team"}
@@ -17,10 +17,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
## Summary

Desbloqueia "Python Library Validation" no CI (falha em todas as PRs e em main desde merge de #76).

## Causa raiz

```toml
requires-python = ">=3.8"   # ← demasiado lasso
```

`opentelemetry-exporter-otlp-proto-grpc==1.41.1` em `dependencies` exige `>=3.9`. Poetry resolve para `>=3.8,<3.13` e falha:

```
Because neural-hive-observability depends on
opentelemetry-exporter-otlp-proto-grpc (1.41.1) which requires Python >=3.9,
version solving failed.
```

## Solução

- `requires-python = ">=3.9"` (alinha com a dep mais restritiva)
- Actualiza classifiers (remove 3.8, adiciona 3.12)

Outras libs do projecto já estão em >=3.10 ou >=3.12. CLAUDE.md indica Python 3.12+ no projecto.

## Test plan

- [ ] Job "Python Library Validation / Install Dependencies" passa nesta PR
- [ ] PRs #77, #78, #79 ficam mergeable sem este blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)