### PR TITLE
fix(sla-management-system): remove duplicate Prometheus metrics

### DIFF
--- a/services/sla-management-system/src/observability/metrics.py
+++ b/services/sla-management-system/src/observability/metrics.py
@@ -18,6 +18,9 @@ class SLAMetrics:
         return cls._instance
 
     def __init__(self):
+        if getattr(self, "_initialized", False):
+            return
+        self._initialized = True
         # Cálculos de Budget
         self.calculations_total = Counter(
             "sla_calculations_total",
@@ -53,88 +56,6 @@ class SLAMetrics:
 
         self.burn_rate = Gauge(
             "sla_burn_rate", "Taxa de consumo do budget", ["slo_id", "service_name", "window_hours"]
-        )
-
-        # SLA Alerts Metrics
-        self.sla_alerts_received_total = Counter(
-            "sla_alerts_received_total",
-            "Total de alertas SLA recebidos",
-            ["severity", "topic", "slo_id", "service_name"],
-        )
-
-        self.sla_notifications_sent_total = Counter(
-            "sla_notifications_sent_total",
-            "Total de notificações SLA enviadas",
-            ["channel", "severity", "slo_id", "service_name"],
-        )
-
-        self.sla_notification_failures_total = Counter(
-            "sla_notification_failures_total",
-            "Total de falhas ao enviar notificações",
-            ["channel", "error_type", "slo_id", "service_name"],
-        )
-
-        self.sla_notification_latency_seconds = Histogram(
-            "sla_notification_latency_seconds",
-            "Latência do envio de notificações",
-            ["channel", "slo_id", "service_name"],
-            buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
-        )
-
-        self.calculation_duration = Histogram(
-            "sla_calculation_duration_seconds",
-            "Duração dos cálculos de budget",
-            ["slo_id", "service_name"],
-            buckets=[0.1, 0.5, 1, 2, 5, 10],
-        )
-
-        # Error Budgets
-        self.budget_remaining = Gauge(
-            "sla_budget_remaining_percent",
-            "Percentual de budget restante",
-            ["slo_id", "service_name", "slo_type"],
-        )
-
-        self.budget_consumed = Gauge(
-            "sla_budget_consumed_percent",
-            "Percentual de budget consumido",
-            ["slo_id", "service_name", "slo_type"],
-        )
-
-        self.budget_status = Gauge(
-            "sla_budget_status",
-            "Status do budget (0=HEALTHY, 1=WARNING, 2=CRITICAL, 3=EXHAUSTED)",
-            ["slo_id", "service_name"],
-        )
-
-        self.burn_rate = Gauge(
-            "sla_burn_rate", "Taxa de consumo do budget", ["slo_id", "service_name", "window_hours"]
-        )
-
-        # SLA Alerts Metrics
-        self.sla_alerts_received_total = Counter(
-            "sla_alerts_received_total",
-            "Total de alertas SLA recebidos",
-            ["severity", "topic", "slo_id", "service_name"],
-        )
-
-        self.sla_notifications_sent_total = Counter(
-            "sla_notifications_sent_total",
-            "Total de notificações SLA enviadas",
-            ["channel", "severity", "slo_id", "service_name"],
-        )
-
-        self.sla_notification_failures_total = Counter(
-            "sla_notification_failures_total",
-            "Total de falhas ao enviar notificações",
-            ["channel", "error_type", "slo_id", "service_name"],
-        )
-
-        self.sla_notification_latency_seconds = Histogram(
-            "sla_notification_latency_seconds",
-            "Latência do envio de notificações",
-            ["channel", "slo_id", "service_name"],
-            buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
         )
 
         # SLA Alerts Metrics


### PR DESCRIPTION
## Summary

Bug latente exposto após PR #78. Pod `sla-management-system-9f97f5c74-nw4lh` (nova imagem com `neural_hive_security`) falha agora com:

```
ValueError: Duplicated timeseries in CollectorRegistry:
{'sla_calculation_duration_seconds', 'sla_calculation_duration_seconds_created', ...}
```

## Causa raiz

`services/sla-management-system/src/observability/metrics.py`:

- **Copy-paste bug**: linhas 84-138 re-definem as mesmas 10 métricas do bloco 22-82; linhas 141-164 re-definem mais 4 alerts/notifications uma 3ª vez.
- **Singleton sem guard**: `SLAMetrics` usa `__new__` para singleton, mas `__init__` é executado em CADA chamada `SLAMetrics()`, tentando re-registar no `CollectorRegistry` global → `ValueError`.

## Solução

1. Remove 82 linhas duplicadas em `__init__`.
2. Adiciona guard de inicialização:
   ```python
   def __init__(self):
       if getattr(self, "_initialized", False):
           return
       self._initialized = True
   ```

## Validação

- `grep -c sla_calculation_duration_seconds` → 1 (era 2)
- 60 → 48 `self.*` assignments
- 427 → 348 linhas

## Test plan

- [ ] Build da nova imagem
- [ ] Pod `sla-management-system` 2/2 Running sem ValueError nos logs
- [ ] Métricas Prometheus expostas no `:9090/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)