### PR TITLE
fix(helm/sla-management-system): enable kopf liveness HTTP endpoint

### DIFF
--- a/helm-charts/sla-management-system/templates/operator-deployment.yaml
+++ b/helm-charts/sla-management-system/templates/operator-deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - run
         - /app/src/operator/main.py
         - --verbose
+        - --liveness=http://0.0.0.0:8080/healthz
         {{- if .Values.operator.watchNamespaces }}
         - --namespace
         - {{ .Values.operator.watchNamespaces | join "," }}


### PR DESCRIPTION
## Summary

Resolve `sla-management-system-operator` em CrashLoopBackOff (11 restarts) — liveness probe contra endpoint inexistente.

## Causa raiz

Operator deployment expõe `:8080` named `http` e tem:
```yaml
livenessProbe:
  httpGet:
    path: /healthz
    port: http
```

Mas o comando é `kopf run /app/src/operator/main.py --verbose` — sem `--liveness`, kopf NÃO inicia HTTP server. `src/operator/main.py` também não inicia nenhum web framework (é puro kopf).

Resultado: Istio sidecar proxy do `/app-health/operator/livez` → :8080 → connection refused → probe falha 3× → SIGTERM → restart loop.

Logs confirmam:
```
SLA Management System Operator started successfully
... 60s mais tarde ...
Signal SIGTERM is received. Operator is stopping.
```

## Solução

Adiciona `--liveness=http://0.0.0.0:8080/healthz` aos args. kopf integra um servidor HTTP interno quando esta flag é fornecida.

## Test plan

- [ ] Após deploy: `kubectl get pod -l app.kubernetes.io/component=operator -n neural-hive` → Running 2/2 estável
- [ ] `kubectl logs ... -c operator` sem `Signal SIGTERM is received`

🤖 Generated with [Claude Code](https://claude.com/claude-code)