### PR TITLE
fix(orchestrator-dynamic): unblock startup — Postgres + Redis config + probe ports (closes #84)

### DIFF
--- a/k8s/orchestrator-dynamic-deployment.yaml
+++ b/k8s/orchestrator-dynamic-deployment.yaml
@@ -38,6 +38,17 @@ data:
   TEMPORAL_NAMESPACE: "default"
   TEMPORAL_TASK_QUEUE: "neural-hive-task-queue"
 
+  # PostgreSQL (Temporal state store) — settings.py linhas 126-132
+  POSTGRES_HOST: "temporal-postgresql.temporal.svc.cluster.local"
+  POSTGRES_PORT: "5432"
+  POSTGRES_DATABASE: "temporal"
+  POSTGRES_USER: "temporal"
+  POSTGRES_SSL_MODE: "disable"
+
+  # Redis Cluster (cache) — settings.py linhas 149-153
+  REDIS_CLUSTER_NODES: "redis-cluster-lb.redis-cluster.svc.cluster.local:6379"
+  REDIS_SSL_ENABLED: "false"
+
   # Context Layer Settings
   ORCHESTRATOR_ENABLE_DYNAMIC_ROUTING: "true"
   ORCHESTRATOR_WORKFLOW_CLASSIFIER_TYPE: "multi_signal"
@@ -94,6 +105,11 @@ stringData:
   MONGODB_PASSWORD: "local_dev_password"
   TEMPORAL_CLIENT_CERT: ""
   TEMPORAL_PRIVATE_KEY: ""
+  # Passwords copiados dos secrets já existentes no cluster (dev defaults).
+  # Produção: substituir por ExternalSecrets/SealedSecrets apontando para
+  # temporal/temporal-default-store e neural-hive/redis-password.
+  POSTGRES_PASSWORD: "temporal"
+  REDIS_PASSWORD: "nhm_redis_2026"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/orchestrator-dynamic-deployment.yaml
+++ b/k8s/orchestrator-dynamic-deployment.yaml
@@ -177,16 +177,18 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "500m"
+        # Probes em 8000 — Uvicorn serve toda a app (/health, /ready, /metrics) no
+        # mesmo port. O 8003 declarado em ports era apenas histórico.
         livenessProbe:
           httpGet:
             path: /health
-            port: 8003
+            port: 8000
           initialDelaySeconds: 30
           periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /ready
-            port: 8003
+            port: 8000
           initialDelaySeconds: 20
           periodSeconds: 10
         volumeMounts:


### PR DESCRIPTION
## Summary

Desbloqueia o startup do orchestrator-dynamic resolvendo 3 problemas latentes que faziam todos os pods novos crasharem (exposto durante o roll-out do PR #83):

1. **ConfigMap em falta**: `POSTGRES_HOST`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `REDIS_CLUSTER_NODES` exigidos por `settings.py:126-153` mas ausentes
2. **Probes no port errado**: liveness/readiness em 8003, app real serve em 8000

Closes #84.

## Antes vs Depois

**Antes:**
```
$ kubectl get pods -n orchestrator-dynamic
NAME                  READY   STATUS
…-5894fb8476-m6w55    1/1     Running             (pod cached, imagem antiga)
…-648b6f58d4-*        0/1     CrashLoopBackOff    (Validation: postgres_host required)
…-685847458d-*        0/1     CrashLoopBackOff    (Validation: redis_cluster_nodes required)
```

**Depois:**
```
$ kubectl get pods -n orchestrator-dynamic
NAME                  READY   STATUS
…-7587dc4966-nvt8t    1/1     Running
…-7c9d9dc4f5-sfbzf    1/1     Running
```

## Commits

- `b221ff40` — adicionar POSTGRES_* + REDIS_CLUSTER_NODES ao ConfigMap, POSTGRES_PASSWORD + REDIS_PASSWORD ao Secret
- `0a63e281` — alinhar liveness/readiness probes em port 8000 (onde a app realmente serve)

## Valores escolhidos

| Variável | Valor | Origem |
|----------|-------|--------|
| POSTGRES_HOST | `temporal-postgresql.temporal.svc.cluster.local` | Service existente em ns `temporal` |
| POSTGRES_USER | `temporal` | Default do chart Bitnami |
| POSTGRES_PASSWORD | `temporal` | secret `temporal/temporal-default-store` (dev default) |
| POSTGRES_SSL_MODE | `disable` | `SHOW ssl` → off no temporal-postgresql |
| REDIS_CLUSTER_NODES | `redis-cluster-lb.redis-cluster.svc.cluster.local:6379` | Service LB do cluster |
| REDIS_PASSWORD | `nhm_redis_2026` | secret `neural-hive/redis-password` |
| REDIS_SSL_ENABLED | `false` | `CONFIG GET tls-cluster` → no |

⚠️ **Produção**: substituir secrets hardcoded por ExternalSecrets/SealedSecrets a apontar para os secrets de origem.

## Test plan

- [x] `kubectl apply -f k8s/orchestrator-dynamic-deployment.yaml` — sucesso
- [x] Logs novos pods mostram `Application startup complete`
- [x] `kubectl get deploy orchestrator-dynamic` mostra 2/3 ready (HPA a estabilizar)
- [ ] Após merge de PR #83 (memory bump + init container fix), HPA estabiliza em 2 réplicas
- [ ] Verificar workflows reais a executar via Temporal

## Relacionado

- PR #83 — memory bump + init container fix (independente, mas complementar)
- Issue #84 — esta PR resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)