### PR TITLE
fix(cluster): persist 2026-05-18 stability hotfixes

### DIFF
--- a/gatekeeper/constraints-applied/gatekeeper-constraints.yaml
+++ b/gatekeeper/constraints-applied/gatekeeper-constraints.yaml
@@ -54,3 +54,43 @@ spec:
       - key: app.kubernetes.io/name
         allowedRegex: "^[a-z0-9-]+$"
     message: "All resources must have 'app' and 'app.kubernetes.io/name' labels"
+
+---
+# 4. Required Labels (variante strict, cluster-wide)
+# Enforça labels 'app' + 'app.kubernetes.io/name' em TODOS os namespaces
+# excepto a lista explícita de namespaces de sistema/infra.
+# `ingress-nginx` foi excluído após incidente 2026-05-18: o DS template
+# do chart bitnami/ingress-nginx só define `app.kubernetes.io/name`
+# (sem `app`), o que bloqueava criação de novos pods do DaemonSet.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: must-have-app-label-all
+spec:
+  enforcementAction: deny
+  match:
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+      - kube-public
+      - kube-node-lease
+      - cert-manager
+      - istio-system
+      - flannel
+      - observability
+      - kafka
+      - longhorn-system
+      - kube-flannel
+      - ingress-nginx
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod", "Deployment", "StatefulSet", "DaemonSet"]
+    namespaces:
+      - "*"
+  parameters:
+    labels:
+      - key: app
+        allowedRegex: "^[a-z0-9-]+$"
+      - key: app.kubernetes.io/name
+        allowedRegex: "^[a-z0-9-]+$"
+    message: "All resources must have 'app' and 'app.kubernetes.io/name' labels"

--- a/helm-charts/mongodb/values-bitnami-override.yaml
+++ b/helm-charts/mongodb/values-bitnami-override.yaml
@@ -1,0 +1,32 @@
+# MongoDB Bitnami chart values override
+#
+# Contexto:
+# O release `mongodb` no namespace `mongodb-cluster` usa o chart
+# upstream `bitnami/mongodb` (não este chart local do repo, que
+# define um operator-based ReplicaSet alternativo).
+#
+# Aplicar com:
+#   helm upgrade mongodb oci://registry-1.docker.io/bitnamicharts/mongodb \
+#     -n mongodb-cluster --reuse-values -f values-bitnami-override.yaml
+#
+# Motivação (incidente 2026-05-18):
+# O readinessProbe padrão do Bitnami invoca `/bitnami/scripts/readiness-probe.sh`
+# que arranca `mongosh` (Node.js). O cold-start do mongosh demora ~25s,
+# mas o probe timeout=5s mata o processo com SIGKILL antes de completar
+# o handshake — deixando processos zombie e o pod permanentemente
+# `ready=false`, com 0 endpoints no service. Cascata:
+# consensus-engine, queen-agent e orchestrator-dynamic falhavam o
+# startup com "connection refused" ao mongodb.mongodb-cluster.svc.
+#
+# Substituímos por tcpSocket check directo ao port 27017 (instant).
+
+customReadinessProbe:
+  tcpSocket:
+    port: mongodb
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 10
+  failureThreshold: 6
+  successThreshold: 1
+
+# Liveness mantém o script Bitnami (timeout 30s já suficiente).

--- a/k8s/orchestrator-dynamic-deployment.yaml
+++ b/k8s/orchestrator-dynamic-deployment.yaml
@@ -33,10 +33,21 @@ data:
   MONGODB_DATABASE: "neural_hive"
 
   # Temporal
-  TEMPORAL_HOST: "neural-hive-temporal.temporal.svc.cluster.local"
+  # Service real é temporal-frontend.temporal.svc; o anterior
+  # "neural-hive-temporal" não existe e provocava DNS lookup failure
+  # bloqueando o startup do orchestrator (incidente 2026-05-18).
+  TEMPORAL_HOST: "temporal-frontend.temporal.svc.cluster.local"
   TEMPORAL_PORT: "7233"
   TEMPORAL_NAMESPACE: "default"
   TEMPORAL_TASK_QUEUE: "neural-hive-task-queue"
+
+  # Scheduler
+  # service-registry está scaled 0/0 (componente cognitivo desactivado).
+  # Com intelligent_scheduler=true, o TemporalWorker._init_components
+  # bloqueia em ServiceRegistryClient.initialize() durante startup e a
+  # ASGI não consegue fazer bind ao port 8000 → startupProbe falha.
+  # Reactivar quando service-registry for re-enable.
+  ENABLE_INTELLIGENT_SCHEDULER: "false"
 
   # PostgreSQL (Temporal state store) — settings.py linhas 126-132
   POSTGRES_HOST: "temporal-postgresql.temporal.svc.cluster.local"
@@ -178,10 +189,23 @@ spec:
             memory: "350Mi"
             cpu: "200m"
           limits:
-            memory: "512Mi"
+            # 1Gi para acomodar picos durante init (Temporal SDK + 4
+            # Kafka consumers + gRPC clients). Anterior 512Mi causava
+            # OOMKill exit 137 (incidente 2026-05-18).
+            memory: "1Gi"
             cpu: "500m"
         # Probes em 8000 — Uvicorn serve toda a app (/health, /ready, /metrics) no
         # mesmo port. O 8003 declarado em ports era apenas histórico.
+        # startupProbe dá 300s de grace ao bootstrap (init container pip
+        # install + Temporal + Kafka rebalance + gRPC channels antes do
+        # uvicorn.run()). Sem isto, livenessProbe matava o pod a 30s.
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          failureThreshold: 60
+          periodSeconds: 5
+          timeoutSeconds: 3
         livenessProbe:
           httpGet:
             path: /health
@@ -234,7 +258,9 @@ spec:
     kind: Deployment
     name: orchestrator-dynamic
   minReplicas: 2
-  maxReplicas: 10
+  # maxReplicas reduzido de 10 para 3 — cluster está memory-bound; HPA
+  # a 10 pods causava Pending por insufficient memory (incidente 2026-05-18).
+  maxReplicas: 3
   metrics:
   - type: Resource
     resource:


### PR DESCRIPTION
## Resumo

Persiste em git os patches aplicados ao cluster via `kubectl/helm` durante o incidente de **2026-05-18** — uma cascade failure originada no readiness probe do MongoDB, com bloqueios secundários em `orchestrator-dynamic`, `consensus-engine`, `queen-agent` e `ingress-nginx-controller`.

Cluster passou de **~4 componentes críticos partidos há 11h** para **192/195 pods Running (98.5%)**.

## Mudanças

### `k8s/orchestrator-dynamic-deployment.yaml`
5 patches no deployment do orchestrator-dynamic em ns próprio:

- **TEMPORAL_HOST** corrigido para `temporal-frontend.temporal.svc.cluster.local` (o anterior `neural-hive-temporal` não existe no cluster — provocava DNS lookup failure que abortava o startup)
- **ENABLE_INTELLIGENT_SCHEDULER=false** — enquanto `service-registry` está 0/0 (componente cognitivo desactivado), o `TemporalWorker._init_components` bloqueia em `ServiceRegistryClient.initialize()` durante o startup, impedindo `uvicorn.run()` de fazer bind ao port 8000 → `startupProbe` falha sempre
- **memory.limit 512Mi → 1Gi** — burst de init (Temporal SDK + 4 Kafka consumers + gRPC clients) causava OOMKill exit 137 (88 restarts em 24h)
- **startupProbe (300s grace)** — bootstrap real demora ~3-5min (init container `pip install neural_hive_context` from git + Temporal + Kafka rebalance + gRPC channels); sem isto a livenessProbe matava o pod aos 30s
- **HPA maxReplicas 10 → 3** — cluster está memory-bound, scale-up >3 causa pods `Pending` com `Insufficient memory`

### `helm-charts/mongodb/values-bitnami-override.yaml` (novo)
- `customReadinessProbe.tcpSocket:27017` substitui o script padrão `/bitnami/scripts/readiness-probe.sh` que invoca `mongosh` (Node.js cold-start ~25s > `timeoutSeconds:5` → SIGKILL → 129 zombies → 0 endpoints no service)
- Ficheiro de override para aplicar com `helm upgrade mongodb oci://registry-1.docker.io/bitnamicharts/mongodb -n mongodb-cluster --reuse-values -f values-bitnami-override.yaml`

### `gatekeeper/constraints-applied/gatekeeper-constraints.yaml`
- Adiciona constraint **`must-have-app-label-all`** (variante strict cluster-wide) que existia no cluster mas não estava tracked no repo
- Inclui `ingress-nginx` em `excludedNamespaces` — o DS do chart `bitnami/ingress-nginx` define apenas `app.kubernetes.io/name` (sem `app`), bloqueando criação de novos pods do DaemonSet em nodes recentes (vmi3306611 / vmi2911680)

## Root Causes Identificados (não tocados nesta PR)

| Issue | Razão de não tocar |
|---|---|
| `mongosh` cold-start lento | Limitação upstream do Bitnami; o probe TCP é o workaround correcto |
| `service-registry` 0/0 | Decisão estratégica histórica (memória 15:15 do dia 2026-05-18); requer re-enable da cognitive pipeline (STE + specialists) |
| Init container pip install do `neural_hive_context` | Demora ~5min por restart; deve ser baked na imagem base (separate build job) |
| 13 cognitive components scaled-down | Estado intencional, fora do scope desta hotfix |

## Test plan

- [ ] Verificar `git diff main..fix/cluster-stability-hotfixes-2026-05-18 -- k8s/` é só os 5 deltas descritos
- [ ] Confirmar live cluster (já validado durante o incidente):
  - `kubectl -n mongodb-cluster get endpoints mongodb` mostra IP
  - `kubectl -n orchestrator-dynamic get deploy` >= 2/3 Ready
  - `kubectl -n ingress-nginx get ds ingress-nginx-controller` mostra 5/5 Ready
- [ ] Após merge, próximo `kubectl apply -f k8s/orchestrator-dynamic-deployment.yaml` (ou re-run do CI) re-applica os fixes sem reverter

🤖 Generated with [Claude Code](https://claude.com/claude-code)