### PR TITLE
fix(mlflow): install psycopg2 at boot + tune gunicorn for postgres backend

### DIFF
--- a/k8s/mlflow-deployment.yaml
+++ b/k8s/mlflow-deployment.yaml
@@ -27,6 +27,10 @@ spec:
     metadata:
       labels:
         app: mlflow
+        # Gatekeeper constraint `must-have-app-label-all` exige ambas as
+        # labels `app` e `app.kubernetes.io/name` em todos os namespaces
+        # não-excluídos. Sem isto, o admission webhook recusa o pod.
+        app.kubernetes.io/name: mlflow
     spec:
       securityContext:
         runAsNonRoot: true
@@ -49,17 +53,30 @@ spec:
             secretKeyRef:
               name: mlflow-postgres-secret
               key: password
+        # mlflow:v2.9.2 não inclui o driver psycopg2 que o backend-store
+        # postgresql:// requer. Instalamos no boot para /tmp/lib (writable
+        # pelo UID 1000 não-root) e injectamos via PYTHONPATH.
+        #
+        # Workers reduzidos para 2 — historicamente o default (4) causou
+        # contenção/deadlock quando o backend ainda era SQLite; com Postgres
+        # 2 workers são suficientes para a carga típica.
+        #
+        # gunicorn timeout 120s (vs default 30s) — o boot do mlflow pode
+        # demorar >30s na primeira request (carrega routes, prepara DB pool),
+        # o que originava SIGKILL dos workers e CrashLoopBackOff repetido.
         command:
-        - mlflow
-        - server
-        - --host
-        - "0.0.0.0"
-        - --port
-        - "5000"
-        - --backend-store-uri
-        - "postgresql://mlflow:$(POSTGRES_PASSWORD)@mlflow-postgresql:5432/mlflow"
-        - --default-artifact-root
-        - "/mlflow/artifacts"
+        - sh
+        - -c
+        - >-
+          pip install --quiet --target=/tmp/lib psycopg2-binary
+          && PYTHONPATH=/tmp/lib:$PYTHONPATH exec
+          mlflow server
+          --host 0.0.0.0
+          --port 5000
+          --backend-store-uri postgresql://mlflow:${POSTGRES_PASSWORD}@mlflow-postgresql:5432/mlflow
+          --default-artifact-root /mlflow/artifacts
+          --workers 2
+          --gunicorn-opts "--timeout 120 --graceful-timeout 60"
         volumeMounts:
         - name: mlflow-data
           mountPath: /mlflow


### PR DESCRIPTION
## Resumo

Persiste os patches aplicados live ao deployment de mlflow durante o incidente **2026-05-18** (pod em `CrashLoopBackOff` há 15 dias, 12 restarts).

O manifesto em `k8s/mlflow-deployment.yaml` já apontava para o backend Postgres mas faltavam 4 itens críticos para o pod arrancar. Resultado: o release deployed no cluster continuava com SQLite via image default — provavelmente um rollback histórico nunca persistido em git.

## Pré-requisito

Este PR depende de **PR #88** que adiciona a constraint Gatekeeper `must-have-app-label-all` ao repo. A label `app.kubernetes.io/name=mlflow` adicionada aqui é exigida por essa constraint. Se PR #88 for revertido, o pod deste deployment continua a passar (label tem só efeito positivo).

## Mudanças

### `k8s/mlflow-deployment.yaml`

| # | Mudança | Causa raiz |
|---|---|---|
| 1 | Adicionar `app.kubernetes.io/name: mlflow` ao pod template | Gatekeeper constraint `must-have-app-label-all` recusa pods sem esta label |
| 2 | Substituir `command` por shell wrapper: `pip install --target=/tmp/lib psycopg2-binary && PYTHONPATH=/tmp/lib exec mlflow server ...` | Image `ghcr.io/mlflow/mlflow:v2.9.2` não inclui o driver. UID 1000 não tem write em `/.local`, por isso `--target=/tmp/lib` |
| 3 | Adicionar `--gunicorn-opts ""--timeout 120 --graceful-timeout 60""` | Default 30s causava `SIGKILL` dos workers + `[CRITICAL] WORKER TIMEOUT` repetido |
| 4 | Adicionar explicitamente `--workers 2` | Defensivo: historicamente, quando o backend era SQLite, 4 workers concorrentes causavam database lock contention |

## Estado pós-fix (cluster live)

```
NAME                      READY   STATUS    RESTARTS   AGE
mlflow-8d6bfc778-s4vz5    1/1     Running   0          5m
mlflow-postgresql-0       1/1     Running   0          31d

NAME      ENDPOINTS           AGE
mlflow    10.244.2.65:5000    200d
```

Schema fresco criado pelo alembic em Postgres (8 migrations). Histórico SQLite anterior (Feb 8 → Mar 17, em `/mlflow/mlflow.db` no PVC) **não foi migrado** — estava num pod morto há 15d sem novas escritas; perda aceitável dado o trade-off com a estabilidade.

## Test plan

- [ ] `git diff main..fix/mlflow-psycopg2-and-worker-tuning -- k8s/mlflow-deployment.yaml` mostra apenas os 4 deltas descritos
- [ ] Aplicar `kubectl apply -f k8s/mlflow-deployment.yaml` num ambiente staging valida ciclo: init pip → alembic migrate → gunicorn ready → endpoint populado
- [ ] Web UI mlflow em http://mlflow.mlflow.svc:5000/ responde 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)