### PR TITLE
fix(specialists): add app podLabel for Gatekeeper compliance

### DIFF
--- a/helm-charts/specialist-architecture/values.yaml
+++ b/helm-charts/specialist-architecture/values.yaml
@@ -2,6 +2,13 @@
 component: "specialist-architecture"
 layer: "cognitiva"
 
+# Gatekeeper constraint `must-have-app-label-all` exige a label simples
+# `app` no pod template (além de `app.kubernetes.io/name` já incluído via
+# selectorLabels). Sem isto, novas réplicas falham admission webhook com:
+#   [must-have-app-label-all] missing required label
+podLabels:
+  app: specialist-architecture
+
 replicaCount: 2
 
 autoscaling:

--- a/helm-charts/specialist-behavior/values.yaml
+++ b/helm-charts/specialist-behavior/values.yaml
@@ -2,6 +2,13 @@
 component: "specialist-behavior"
 layer: "cognitiva"
 
+# Gatekeeper constraint `must-have-app-label-all` exige a label simples
+# `app` no pod template (além de `app.kubernetes.io/name` já incluído via
+# selectorLabels). Sem isto, novas réplicas falham admission webhook com:
+#   [must-have-app-label-all] missing required label
+podLabels:
+  app: specialist-behavior
+
 replicaCount: 2
 
 autoscaling:

--- a/helm-charts/specialist-business/values.yaml
+++ b/helm-charts/specialist-business/values.yaml
@@ -2,6 +2,13 @@
 component: "specialist-business"
 layer: "cognitiva"
 
+# Gatekeeper constraint `must-have-app-label-all` exige a label simples
+# `app` no pod template (além de `app.kubernetes.io/name` já incluído via
+# selectorLabels). Sem isto, novas réplicas falham admission webhook com:
+#   [must-have-app-label-all] missing required label
+podLabels:
+  app: specialist-business
+
 replicaCount: 2
 
 autoscaling:

--- a/helm-charts/specialist-evolution/values.yaml
+++ b/helm-charts/specialist-evolution/values.yaml
@@ -2,6 +2,13 @@
 component: "specialist-evolution"
 layer: "cognitiva"
 
+# Gatekeeper constraint `must-have-app-label-all` exige a label simples
+# `app` no pod template (além de `app.kubernetes.io/name` já incluído via
+# selectorLabels). Sem isto, novas réplicas falham admission webhook com:
+#   [must-have-app-label-all] missing required label
+podLabels:
+  app: specialist-evolution
+
 replicaCount: 2
 
 autoscaling:

--- a/helm-charts/specialist-technical/values.yaml
+++ b/helm-charts/specialist-technical/values.yaml
@@ -2,6 +2,13 @@
 component: "specialist-technical"
 layer: "cognitiva"
 
+# Gatekeeper constraint `must-have-app-label-all` exige a label simples
+# `app` no pod template (além de `app.kubernetes.io/name` já incluído via
+# selectorLabels). Sem isto, novas réplicas falham admission webhook com:
+#   [must-have-app-label-all] missing required label
+podLabels:
+  app: specialist-technical
+
 replicaCount: 2
 
 autoscaling:


### PR DESCRIPTION
## Resumo

Os 5 specialists (business, technical, architecture, behavior, evolution) falham admission webhook ao escalar novas réplicas:

\`\`\`
[must-have-app-label-all] missing required label,
requires all of: app, app.kubernetes.io/name
\`\`\`

A constraint cluster-wide \`must-have-app-label-all\` (ver **PR #88**) exige ambas as labels. O common template \`neural-hive.selectorLabels\` em \`helm-charts/common-templates/templates/_helpers.tpl\` inclui apenas \`app.kubernetes.io/name\` e \`app.kubernetes.io/instance\` — a label simples \`app\` está em falta.

## Mudanças

5 ficheiros, +35/-0 linhas (todas iguais — 7 linhas a cada \`values.yaml\`):

| Ficheiro | Adiciona |
|---|---|
| \`helm-charts/specialist-business/values.yaml\` | \`podLabels: {app: specialist-business}\` |
| \`helm-charts/specialist-technical/values.yaml\` | \`podLabels: {app: specialist-technical}\` |
| \`helm-charts/specialist-architecture/values.yaml\` | \`podLabels: {app: specialist-architecture}\` |
| \`helm-charts/specialist-behavior/values.yaml\` | \`podLabels: {app: specialist-behavior}\` |
| \`helm-charts/specialist-evolution/values.yaml\` | \`podLabels: {app: specialist-evolution}\` |

\`podLabels\` é suportado nativamente pelo common deployment template \`_deployment.tpl\` linha 74 (\`{{- with \$values.podLabels }}\`).

## Porque NÃO no template comum

A alternativa óbvia seria adicionar \`app: ...\` ao \`neural-hive.selectorLabels\` (uma linha em \`_helpers.tpl\`). **Inviável** porque:

1. \`spec.selector.matchLabels\` é **imutável** em \`apps/v1.Deployment\`
2. Todos os specialists já existentes têm matchLabels apenas com \`app.kubernetes.io/name\` + \`app.kubernetes.io/instance\`
3. Adicionar \`app\` a selectorLabels mudaria matchLabels → \`helm upgrade\` falharia com \`field is immutable\`

\`podLabels\` afecta apenas pod metadata, não o selector — caminho seguro.

## Evidência live

\`\`\`
$ kubectl -n neural-hive get deploy specialist-business -o jsonpath='{.spec.selector.matchLabels}'
{"app.kubernetes.io/instance":"specialist-business","app.kubernetes.io/name":"specialist-business"}

$ kubectl -n neural-hive get pods -l app.kubernetes.io/name=specialist-technical
NAME                                READY   STATUS    ...
[FailedCreate: must-have-app-label-all]
\`\`\`

Eu já fiz patch live aos deployments de \`specialist-technical\`, \`specialist-behavior\`, \`specialist-evolution\` durante a sessão (memory drift); este PR re-alinha o git source-of-truth para sourcing consistente via Helm.

## Test plan

- [ ] \`helm template specialist-business helm-charts/specialist-business | grep -A 3 'metadata:' | grep 'app:'\` mostra a label
- [ ] \`helm template specialist-business helm-charts/specialist-business | grep 'matchLabels:' -A 3\` NÃO inclui \`app:\` (preserva immutability)
- [ ] \`helm upgrade specialist-business helm-charts/specialist-business --reuse-values\` em staging não dá erro de immutable selector
- [ ] Novos pods do specialist-business passam Gatekeeper admission

🤖 Generated with [Claude Code](https://claude.com/claude-code)