### PR TITLE
fix(service-registry): re-enable + flexible secret key sourcing

### DIFF
--- a/helm-charts/service-registry/templates/deployment.yaml
+++ b/helm-charts/service-registry/templates/deployment.yaml
@@ -14,7 +14,8 @@
 {{- $env = append $env (dict "name" "HEARTBEAT_TIMEOUT_SECONDS" "value" (printf "%d" (int .Values.config.heartbeat.timeoutSeconds))) }}
 {{- $env = append $env (dict "name" "REDIS_CLUSTER_NODES" "value" (.Values.config.redis.clusterNodes | toJson)) }}
 {{- $redisSecretName := .Values.config.redis.existingSecret | default (printf "%s-secret" (include "service-registry.fullname" .)) }}
-{{- $env = append $env (dict "name" "REDIS_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" $redisSecretName "key" "redis-password"))) }}
+{{- $redisSecretKey := .Values.config.redis.existingSecretKey | default "redis-password" }}
+{{- $env = append $env (dict "name" "REDIS_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" $redisSecretName "key" $redisSecretKey))) }}
 {{- $env = append $env (dict "name" "OTEL_EXPORTER_ENDPOINT" "value" .Values.config.otel.exporterEndpoint) }}
 
 {{/* SPIFFE environment variables */}}

--- a/helm-charts/service-registry/values-k8s.yaml
+++ b/helm-charts/service-registry/values-k8s.yaml
@@ -2,7 +2,20 @@
 # Neural Hive-Mind - Production/Kubernetes deployment
 # Override values for Kubernetes environments
 
-replicaCount: 0  # Disabled: image not found in registry
+# Re-enabled 2026-05-18: imagem ghcr.io/.../service-registry:c762d89 verificada
+# como funcional no cluster. Bloqueio anterior era um secret `service-registry-secret`
+# com chave `redis-password` vazia; agora o chart suporta `existingSecretKey` para
+# apontar para o secret partilhado `redis-password` (chave `password`).
+# service-registry é dependência crítica do orchestrator-dynamic intelligent_scheduler.
+replicaCount: 1
+
+# Sourcing do password de Redis a partir do secret partilhado em vez de gerar
+# vazio. O secret `redis-password` no namespace neural-hive contém a chave
+# `password` com a credencial real.
+config:
+  redis:
+    existingSecret: "redis-password"
+    existingSecretKey: "password"
 
 image:
   repository: ghcr.io/albinojimy/neural-hive-mind/service-registry

--- a/helm-charts/service-registry/values.yaml
+++ b/helm-charts/service-registry/values.yaml
@@ -75,6 +75,10 @@ config:
     # Nome do secret existente que contem a chave 'redis-password'
     # Se definido, o chart NAO criara o Secret (usa o existente)
     existingSecret: ""  # Ex: "service-registry-secret" criado por ExternalSecret
+    # Nome da chave dentro do existingSecret (default: "redis-password")
+    # Util quando o secret externo usa convencao diferente. Ex: o secret
+    # `redis-password` partilhado em neural-hive expoe a chave `password`.
+    existingSecretKey: ""  # Default = "redis-password" se vazio
   otel:
     exporterEndpoint: http://otel-collector:4317
 


### PR DESCRIPTION
## Resumo

Persiste o re-enable feito live ao **service-registry** durante o incidente 2026-05-18. O comentário em \`values-k8s.yaml\` (\"image not found in registry\") era enganoso — a imagem \`ghcr.io/.../service-registry:c762d89\` é funcional. O bloqueio real era um secret com chave \`redis-password\` vazia (helm-gerado por defeito quando \`existingSecret\` está em branco).

## Mudanças (3 ficheiros, +20 / −2)

### 1. \`templates/deployment.yaml\`
Suporte para chave configurável no \`existingSecret\`. Anteriormente hardcoded a \`redis-password\`; agora respeita \`.Values.config.redis.existingSecretKey\` com default mantido para back-compat.

\`\`\`diff
+ {{- \$redisSecretKey := .Values.config.redis.existingSecretKey | default "redis-password" }}
- key": "redis-password"
+ key": \$redisSecretKey
\`\`\`

### 2. \`values.yaml\`
Adiciona o novo value documentado (default vazio = comportamento antigo).

### 3. \`values-k8s.yaml\`
\`replicaCount: 0 → 1\` e aponta para o secret partilhado em vez de gerar um próprio vazio:

\`\`\`yaml
config:
  redis:
    existingSecret: "redis-password"
    existingSecretKey: "password"
\`\`\`

## Porque importa

\`service-registry\` é **dependência crítica** do \`orchestrator-dynamic\` quando \`ENABLE_INTELLIGENT_SCHEDULER=true\` (default no chart). Sem service-registry funcional, o \`TemporalWorker._init_components\` bloqueia em \`ServiceRegistryClient.initialize()\` durante boot, impedindo o uvicorn de fazer bind ao port 8000 → \`startupProbe\` falha em loop.

O PR #88 desactivou temporariamente o \`ENABLE_INTELLIGENT_SCHEDULER\` no orchestrator-dynamic precisamente por causa disto. Com este PR mergeado, é seguro reverter o flag a \`true\`.

## Validação live (2026-05-18)

\`\`\`
$ kubectl -n neural-hive get deploy service-registry
NAME               READY   UP-TO-DATE   AVAILABLE
service-registry   1/1     1            1

$ kubectl -n neural-hive get endpoints service-registry
NAME               ENDPOINTS                                AGE
service-registry   10.244.1.105:50051,10.244.1.105:9090     104d
\`\`\`

## Test plan

- [ ] \`helm template service-registry helm-charts/service-registry -f helm-charts/service-registry/values-k8s.yaml\` gera deployment com env \`REDIS_PASSWORD.valueFrom.secretKeyRef.name=redis-password, key=password\`
- [ ] Back-compat: \`helm template service-registry helm-charts/service-registry\` (sem values-k8s) mantém o comportamento antigo
- [ ] Após \`helm upgrade\`, o pod arranca sem erro de autenticação Redis

## Relação com outros PRs

- **#88** desactivou \`ENABLE_INTELLIGENT_SCHEDULER\` no orchestrator-dynamic. Após merge deste #91, reverter aquele flag a \`true\` (próximo PR ou patch directo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)