### PR TITLE
fix(docker-registry): rightsize memory request 256Mi -> 64Mi

### DIFF
--- a/helm-charts/docker-registry/values.yaml
+++ b/helm-charts/docker-registry/values.yaml
@@ -49,10 +49,14 @@ proxy:
   ttl: 168h
 
 # Resource limits
+# Rightsized 2026-05-18: uso real observado em production = ~9Mi memory / 1m CPU
+# (docker-registry é stateless, apenas serve blobs via storage backend). Request
+# anterior de 256Mi/100m representava ~28x sobre-alocação de memória; limit
+# mantém-se generoso para picos de upload concorrente.
 resources:
   requests:
-    memory: "256Mi"
-    cpu: "100m"
+    memory: "64Mi"
+    cpu: "20m"
   limits:
     memory: "512Mi"
     cpu: "500m"


### PR DESCRIPTION
## Resumo

Auditoria do cluster em 2026-05-18 identificou \`docker-registry\` como o **top waster relativo** com 28x sobre-alocação de memória.

| Métrica | Valor |
|---|---|
| Request | 256Mi |
| Actual usage (steady) | 9Mi |
| Waste | 247Mi (96% idle) |
| Ratio request/actual | 28.4x |

\`docker-registry\` é stateless e serve apenas blobs via storage backend (S3/PVC). Memory usage steady-state é dominado por gunicorn idle workers (~9Mi). Reduzido para 64Mi mantém >7x headroom para picos de upload concorrente.

## Mudança

\`\`\`diff
 resources:
   requests:
-    memory: "256Mi"
-    cpu: "100m"
+    memory: "64Mi"
+    cpu: "20m"
   limits:
     memory: "512Mi"
     cpu: "500m"
\`\`\`

Limit mantém-se em 512Mi (sem alteração) — generoso para picos.

## Impacto

Liberta **~192Mi de capacity** no cluster.

Contexto: o cluster está actualmente memory-bound (4 de 5 workers >95% memory requested). Cada Mi libertado é capacity utilizável para re-enable do cognitive pipeline (specialists em scaled-down precisam de 1Gi cada para re-enable).

## Top wasters identificados (próximos candidatos)

| Pod | Request | Actual | Ratio |
|---|---|---|---|
| istiod (istio-system) | 2048Mi | 287Mi | 7.1x |
| neo4j-0 | 2048Mi | 391Mi | 5.2x ⚠️ não tocar (JVM) |
| keycloak-postgresql-0 | 512Mi | 53Mi | 9.7x |
| gatekeeper-controller-manager × 2 | 512Mi | 85Mi | 6x |
| gatekeeper-audit | 512Mi | 128Mi | 4x |
| **docker-registry** | **256Mi** | **9Mi** | **28x** ← este PR |

**istiod**, **keycloak-postgresql**, **gatekeeper** estão deployed via upstream charts (não local). Para reduzir os deles, seria necessário um padrão de values-override (como o \`helm-charts/mongodb/values-bitnami-override.yaml\` do PR #88).

## Test plan

- [ ] \`helm template helm-charts/docker-registry\` produz Deployment com novos requests
- [ ] \`helm upgrade registry helm-charts/docker-registry -n registry --reuse-values\` aplica sem downtime
- [ ] Após upgrade, \`kubectl top pod -n registry\` continua a mostrar ~9Mi de uso real (não-impactado)
- [ ] Smoke test: \`docker pull <registry>/some-image:tag\` continua a funcionar

🤖 Generated with [Claude Code](https://claude.com/claude-code)