### PR TITLE
docs(istio): add istiod memory rightsize override values file

### DIFF
--- a/helm-charts/istio-base/values-istiod-override.yaml
+++ b/helm-charts/istio-base/values-istiod-override.yaml
@@ -1,0 +1,37 @@
+# Istiod Helm chart values override
+#
+# Contexto:
+# O release `istiod` no namespace `istio-system` usa o chart upstream
+# `istiod-1.20.0` (não há chart local). Este ficheiro documenta o override
+# de resources para aplicar via:
+#
+#   helm upgrade istiod istio/istiod -n istio-system \
+#     --version 1.20.0 --reuse-values -f values-istiod-override.yaml
+#
+# Motivação (auditoria 2026-05-18):
+# istiod foi identificado como o top waster absoluto do cluster:
+#
+#   request:  cpu=150m  memory=2Gi
+#   actual:   cpu=16m   memory=296Mi
+#   waste:    cpu=134m  memory=1761Mi  (ratio 7.1x)
+#
+# istiod é o control-plane do Istio service mesh. Memória steady-state
+# escala com:
+#   - número de Services no cluster (~50 actualmente)
+#   - número de pods com sidecar Envoy
+#   - número de Custom Resources (DestinationRule, VirtualService, etc)
+#
+# Para uma malha com ~200 pods e <100 services, 1Gi é generoso. 512Mi
+# seria adequado para pequenos clusters mas damos folga 2x.
+#
+# Risco: LOW. Limit não definido por defeito (apenas request) — pod
+# pode esticar até OOM do node se necessário. CPU também sem limit no
+# istiod por convenção (latency-sensitive). Manter assim.
+
+pilot:
+  # Reduzido de 2Gi → 1Gi após observação de uso real ~300Mi steady.
+  # Liberta ~1Gi de capacity no node que hospeda istiod.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 1Gi


### PR DESCRIPTION
## Resumo

Auditoria 2026-05-18 identificou **istiod** como o top waster absoluto do cluster (1.7Gi desperdiçados em todos os momentos). Este PR adiciona ficheiro de override (sem auto-apply) documentando a redução recomendada.

| Métrica | Valor |
|---|---|
| Request actual | 2Gi |
| Actual usage | 296Mi |
| Waste | 1.7Gi (ratio 7.1x) |
| **Reduzido para** | **1Gi** |
| **Economia** | **1Gi** (>3x headroom mantido) |

## Padrão consistente com PR #88

Este ficheiro segue o mesmo pattern de \`helm-charts/mongodb/values-bitnami-override.yaml\` introduzido no PR #88. O istiod é deployed via chart upstream (\`istio/istiod-1.20.0\`), não há chart local. O override é aplicado pelo operador via:

\`\`\`bash
helm upgrade istiod istio/istiod -n istio-system --version 1.20.0 \\
  --reuse-values -f helm-charts/istio-base/values-istiod-override.yaml
\`\`\`

## Mudança

1 ficheiro novo: \`helm-charts/istio-base/values-istiod-override.yaml\` (37 linhas, incluindo comentários extensos sobre racional e como aplicar)

\`\`\`yaml
pilot:
  resources:
    requests:
      cpu: 100m
      memory: 1Gi    # Antes: 2Gi
\`\`\`

## Porque 1Gi (não 512Mi)

istiod é o control plane do service mesh. Memória escala com:
- Número de Services no cluster (~50 actualmente)
- Número de pods com sidecar Envoy (~150)
- Custom Resources Istio (DestinationRule, VirtualService, etc)

Para esta dimensão de cluster, 512Mi seria adequado mas damos folga 2x para crescimento orgânico. Limit não definido por defeito (apenas request) — pod pode esticar até OOM do node se necessário.

## Test plan

- [ ] \`helm template istiod istio/istiod --version 1.20.0 -f helm-charts/istio-base/values-istiod-override.yaml | grep -A 4 'requests:'\` mostra \`memory: 1Gi\`
- [ ] Após aplicar via helm upgrade, \`kubectl -n istio-system describe deploy istiod\` mostra request 1Gi
- [ ] istiod continua funcional (Envoys recebem xDS updates, sidecar injection works)
- [ ] Memory usage steady ainda <70% do novo request (~300Mi / 1024Mi = 30%)

## Outros top wasters identificados (não neste PR)

| Pod | Request | Actual | Possível saving |
|---|---|---|---|
| keycloak-postgresql-0 | 512Mi | 53Mi | 320Mi |
| gatekeeper-controller-manager × 2 | 512Mi | 85Mi | 512Mi (256 × 2) |
| gatekeeper-audit | 512Mi | 128Mi | 256Mi |

Total potencial adicional: **~1.1Gi**. Podem ser PRs follow-up com mesmo padrão de \`values-override.yaml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)