### PR TITLE
docs(gatekeeper): add cluster override values for memory rightsizing

### DIFF
--- a/helm-charts/opa-gatekeeper/values-cluster-override.yaml
+++ b/helm-charts/opa-gatekeeper/values-cluster-override.yaml
@@ -1,0 +1,40 @@
+# Gatekeeper Helm chart values override (upstream chart)
+#
+# Contexto:
+# O release `gatekeeper` no namespace `gatekeeper-system` usa o chart
+# upstream `gatekeeper-3.22.0`, NÃO o wrapper local `opa-gatekeeper`
+# deste repo (que aponta para gatekeeper-3.14.0).
+#
+# Aplicar com:
+#   helm upgrade gatekeeper gatekeeper/gatekeeper -n gatekeeper-system \
+#     --version 3.22.0 --reuse-values \
+#     -f helm-charts/opa-gatekeeper/values-cluster-override.yaml
+#
+# Motivação (auditoria 2026-05-18):
+# Os 3 componentes do Gatekeeper estavam todos a 512Mi request com uso
+# real de 85-128Mi (ratio 4-6x sobre-alocado):
+#
+#   controllerManager × 2 réplicas:  request=512Mi  actual=85Mi  waste=854Mi total
+#   audit:                            request=512Mi  actual=128Mi waste=384Mi
+#
+# Total reduzível: ~768Mi (1.2Gi com headroom mantido).
+#
+# Risco: LOW. Gatekeeper é stateless (constraints em CRDs). Workload é
+# admission webhook validation + audit, ambos de baixa memória.
+# 256Mi request mantém ~2-3x headroom face ao observado.
+
+controllerManager:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi     # Antes: 512Mi
+    limits:
+      memory: 512Mi     # Mantém limit alto para picos transientes
+
+audit:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi     # Antes: 512Mi
+    limits:
+      memory: 512Mi


### PR DESCRIPTION
## Resumo

Auditoria 2026-05-18 identificou os 3 componentes do Gatekeeper como sobre-alocados em memória (4-6x acima do uso real). Este PR adiciona ficheiro de override documentado.

| Componente | Request | Actual | Waste | Novo |
|---|---|---|---|---|
| controllerManager × 2 réplicas | 512Mi | 85Mi | 854Mi total | 256Mi |
| audit | 512Mi | 128Mi | 384Mi | 256Mi |

**Total reduzível: ~768Mi**.

## Mudança

1 ficheiro novo: \`helm-charts/opa-gatekeeper/values-cluster-override.yaml\` (40 linhas)

\`\`\`yaml
controllerManager:
  resources:
    requests:
      memory: 256Mi    # Antes: 512Mi
    limits:
      memory: 512Mi    # mantém limit para picos

audit:
  resources:
    requests:
      memory: 256Mi    # Antes: 512Mi
    limits:
      memory: 512Mi
\`\`\`

## Como aplicar

\`\`\`bash
helm upgrade gatekeeper gatekeeper/gatekeeper -n gatekeeper-system \\
  --version 3.22.0 --reuse-values \\
  -f helm-charts/opa-gatekeeper/values-cluster-override.yaml
\`\`\`

## Porque override file (e não values.yaml do chart local)

O release deployed no cluster usa o chart **upstream** \`gatekeeper-3.22.0\`, NÃO o wrapper local \`helm-charts/opa-gatekeeper/\` deste repo (que aponta para \`gatekeeper-3.14.0\`, desactualizado).

Por isso o override fica como ficheiro de operador documentado em \`helm-charts/opa-gatekeeper/\` — agnostic à versão do upstream chart.

Padrão consistente com:
- **PR #88**: \`helm-charts/mongodb/values-bitnami-override.yaml\`
- **PR #94**: \`helm-charts/istio-base/values-istiod-override.yaml\`

## Test plan

- [ ] \`helm template gatekeeper gatekeeper/gatekeeper --version 3.22.0 -f helm-charts/opa-gatekeeper/values-cluster-override.yaml | grep -A 4 'requests:' | head -10\` mostra \`memory: 256Mi\` em controllerManager e audit
- [ ] Após \`helm upgrade\`, \`kubectl top pod -n gatekeeper-system\` continua a mostrar uso ~85-128Mi (não impactado pela mudança de request, só capacity planning)
- [ ] Admission webhook continua a recusar pods com labels em falta (constraint \`must-have-app-label-all\` funcional)
- [ ] Audit reports continuam a popular violations CRDs

## Outros wasters identificados nesta auditoria

| Pod | Já PR? |
|---|---|
| istiod 2Gi → 1Gi | #94 ✅ |
| docker-registry 256Mi → 64Mi | #93 ✅ |
| **gatekeeper × 3 → 256Mi** | **#95 (este)** |
| keycloak-postgresql 512Mi → 192Mi | pendente |

🤖 Generated with [Claude Code](https://claude.com/claude-code)