### PR TITLE
fix(keycloak): rightsize postgresql primary memory 512Mi -> 192Mi

### DIFF
--- a/helm-charts/keycloak/values.yaml
+++ b/helm-charts/keycloak/values.yaml
@@ -86,10 +86,14 @@ postgresql:
       enabled: true
       size: 10Gi
       storageClass: "gp3-ssd"
+    # Rightsized 2026-05-18: uso real observado em production = 53Mi memory / 19m CPU
+    # keycloak-postgresql tem carga mínima (apenas auth state, sem cache pesado).
+    # Request 192Mi mantém ~3.6x headroom face ao steady-state; limit 1Gi continua
+    # generoso para picos de migração/backup.
     resources:
       requests:
-        cpu: 250m
-        memory: 512Mi
+        cpu: 50m
+        memory: 192Mi
       limits:
         cpu: 1
         memory: 1Gi


### PR DESCRIPTION
## Resumo

Último waster da série de auditoria 2026-05-18. \`keycloak-postgresql-0\` está sobre-alocado **9.7x** em memória.

| Métrica | Valor |
|---|---|
| Request memory | 512Mi |
| Actual usage | 53Mi |
| Waste | 459Mi (90% idle) |
| Ratio | 9.7x |
| Request CPU | 250m |
| Actual CPU | 19m |

\`keycloak-postgresql\` tem carga mínima (apenas auth state da Keycloak). Sem caches pesados, sem grandes pools de conexão. 192Mi mantém ~3.6x headroom face ao steady-state. Limit (1Gi) preservado para picos de migração/backup.

## Mudança

\`\`\`diff
 primary:
   resources:
     requests:
-      cpu: 250m
-      memory: 512Mi
+      cpu: 50m
+      memory: 192Mi
     limits:
       cpu: 1
       memory: 1Gi
\`\`\`

1 ficheiro: \`helm-charts/keycloak/values.yaml\` (chart LOCAL, subchart \`postgresql\` controlado por estas values).

## Total cumulativo da série memory rightsize

| PR | Componente | Libertado |
|---|---|---|
| #93 | docker-registry | 192Mi |
| #94 | istiod (override) | 1Gi |
| #95 | gatekeeper × 3 (override) | 768Mi |
| **#96** | **keycloak-postgresql** | **320Mi** |
| **Total** | | **~2.3Gi** |

**~2.3Gi de capacity recuperada** se todos forem mergeados/aplicados. Suficiente para re-enable de 4 specialists (1Gi cada, com base nos requests dos charts) num cluster que estava memory-bound.

## Test plan

- [ ] \`helm template helm-charts/keycloak\` produz Deployment com novos requests
- [ ] \`helm upgrade keycloak helm-charts/keycloak -n keycloak --reuse-values\` aplica sem downtime
- [ ] Após upgrade, \`kubectl top pod -n keycloak\` continua a mostrar ~53Mi usage
- [ ] Login Keycloak continua a funcionar (smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)