### PR TITLE
fix(k8s): pin :latest tags HIGH severity (approval-service, self-healing-engine)

### DIFF
--- a/services/approval-service/kubernetes/ml-retrainer-cronjob.yaml
+++ b/services/approval-service/kubernetes/ml-retrainer-cronjob.yaml
@@ -39,7 +39,7 @@ spec:
 
           containers:
           - name: ml-retrainer
-            image: 37.60.241.150:30500/approval-service:latest
+            image: ghcr.io/albinojimy/neural-hive-mind/approval-service:05ca2b2
             imagePullPolicy: Always
             command:
             - python

--- a/services/self-healing-engine/kubernetes/deployment.yaml
+++ b/services/self-healing-engine/kubernetes/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         readOnlyRootFilesystem: false
       containers:
       - name: self-healing-engine
-        image: 37.60.241.150:30500/self-healing-engine:latest
+        image: ghcr.io/albinojimy/neural-hive-mind/self-healing-engine:4da71a3
         imagePullPolicy: Always
         ports:
         - name: http


### PR DESCRIPTION
## Summary

Pin `:latest` em 2 ficheiros K8s de produção e alinha o registry com o que está realmente deployed (ghcr.io em vez do Contabo local instável).

- `services/approval-service/kubernetes/ml-retrainer-cronjob.yaml:42`
- `services/self-healing-engine/kubernetes/deployment.yaml:31`

## Context

Auditoria profunda identificou 8 ficheiros com `:latest` não flaggados pelo CI scanner actual. Estes 2 são **HIGH severity** porque estão em paths de produção (CronJob ML retrainer + Deployment estratégico de self-healing).

**Porque escapavam ao CI:** o scanner em `.github/workflows/validate-infrastructure.yml` (linhas 251-287) cobre apenas `k8s/`, `helm-charts/`, `ml_pipelines/k8s/`. Não cobre `services/*/kubernetes/`.

**Tags escolhidas:** commit hashes actualmente deployed em produção no namespace `neural-hive`, obtidas via `kubectl get deploy ... -o jsonpath`:
- `ghcr.io/albinojimy/neural-hive-mind/approval-service:05ca2b2`
- `ghcr.io/albinojimy/neural-hive-mind/self-healing-engine:4da71a3`

**Mudança de registry:** os manifests apontavam para `37.60.241.150:30500` (registry Contabo local) mas produção real usa `ghcr.io/albinojimy/neural-hive-mind/...`. O registry Contabo tem packet loss conhecido (ver `CONTABO_TICKET.md`) e ~23 imagens missing, tornando estes manifests não-aplicáveis no estado anterior.

## Out of scope (próximos PRs)

- Ampliação do CI scanner para cobrir `services/*/kubernetes/`, `infrastructure/fluxcd/`, `infrastructure/terraform/`, `docker-compose*.yml` (6 ficheiros MEDIUM/LOW remanescentes).
- Decisão sobre namespace consolidation `neural-hive` vs `neural-hive-prod`.
- Helm rollback dos 21 releases FAILED (categoria A primeiro).

## Test plan

- [ ] CI passa (validate-infrastructure check)
- [ ] `grep -rn ':latest' services/approval-service/ services/self-healing-engine/ --include='*.yaml'` retorna 0 hits
- [ ] Manifests editados continuam YAML válidos

Co-Authored-By: Claude Opus 4.7 (1M context)