### PR TITLE
feat(registry): pull-through proxy ghcr.io (mitigação vmi3306611 flakiness)

### DIFF
--- a/helm-charts/docker-registry/README.md
+++ b/helm-charts/docker-registry/README.md
@@ -61,6 +61,61 @@ curl http://registry.neural-hive.local:5000/metrics
 ./scripts/deploy-registry-ha.sh rollback
 ```
 
+## Modo pull-through proxy (cache ghcr.io)
+
+Para mitigar instabilidade de rede com ghcr.io no node vmi3306611
+(packet loss intermitente no backbone Contabo, DNS lento ~2s), o
+registry pode ser reconfigurado como pull-through cache. Pulls são
+servidos da rede interna (NodePort 30500 no master), eliminando
+travessia de backbone externo para imagens já cacheadas.
+
+**Trade-off:** em modo proxy, o registry deixa de aceitar push.
+Confirmar que nenhum pipeline faz push para `37.60.241.150:30500`
+antes de activar.
+
+### Activar server-side
+
+```bash
+helm upgrade registry helm-charts/docker-registry \
+  -n registry \
+  -f helm-charts/docker-registry/values-pullthrough-ghcr.yaml
+```
+
+### Configurar containerd (em CADA nó)
+
+Criar `/etc/containerd/certs.d/ghcr.io/hosts.toml`:
+
+```toml
+server = "https://ghcr.io"
+
+[host."http://37.60.241.150:30500"]
+  capabilities = ["pull", "resolve"]
+```
+
+E garantir que `/etc/containerd/config.toml` tem:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+```
+
+Recarregar containerd (não restart hard, evita matar pods):
+
+```bash
+systemctl reload containerd  # ou kill -SIGHUP $(pidof containerd)
+```
+
+### Validar
+
+```bash
+# A partir de um pod no cluster
+crictl pull ghcr.io/albinojimy/neural-hive-mind/approval-service:05ca2b2
+
+# No master, ver cache populado
+curl http://localhost:30500/v2/_catalog
+# Deve listar albinojimy/neural-hive-mind/approval-service
+```
+
 ## Troubleshooting
 
 ### Registry indisponível

--- a/helm-charts/docker-registry/values-pullthrough-ghcr.yaml
+++ b/helm-charts/docker-registry/values-pullthrough-ghcr.yaml
@@ -1,0 +1,108 @@
+# Pull-through proxy cache para ghcr.io
+#
+# Contexto:
+#   vmi3306611 (worker node Contabo) tem packet loss intermitente no
+#   backbone para destinos externos. ghcr.io é alcançável mas com DNS
+#   lento (~2s) e timeouts ocasionais, causando ImagePullBackOff
+#   esporádicos e cascading helm release failures.
+#
+# Esta configuração transforma o docker-registry interno (NodePort
+# 30500 no master vmi2092350) em pull-through cache de ghcr.io. Pulls
+# subsequentes de imagens já cacheadas são servidos da rede interna
+# Contabo (sem travessia de backbone externo), eliminando a janela de
+# fragilidade do ghcr.
+#
+# IMPORTANTE: quando `proxy.enabled: true`, o registry fica em modo
+# proxy-only e DEIXA DE ACEITAR PUSH. Confirme que nenhum pipeline
+# ainda faz push para 37.60.241.150:30500 antes de aplicar.
+#
+# Para activar:
+#   helm upgrade registry helm-charts/docker-registry \
+#     -n registry \
+#     -f helm-charts/docker-registry/values-pullthrough-ghcr.yaml
+#
+# Para usar no cluster (client-side, em cada node):
+#   /etc/containerd/certs.d/ghcr.io/hosts.toml:
+#     server = "https://ghcr.io"
+#     [host."http://37.60.241.150:30500"]
+#       capabilities = ["pull", "resolve"]
+#
+# Ver helm-charts/docker-registry/README.md para detalhes.
+
+replicaCount: 1
+
+image:
+  repository: registry
+  tag: "2.8.3"
+  pullPolicy: IfNotPresent
+
+service:
+  type: NodePort
+  port: 5000
+  nodePort: 30500
+
+# Persistence: cache de blobs ghcr.io. 50Gi é folgado para imagens
+# do projecto (típico: 200-800Mi por imagem, ~30 imagens = ~15Gi).
+persistence:
+  enabled: true
+  storageClass: ""
+  size: 50Gi
+  accessMode: ReadWriteOnce
+
+storage:
+  s3:
+    enabled: false
+
+redis:
+  enabled: false
+
+# Proxy mode — pull-through cache de ghcr.io
+proxy:
+  enabled: true
+  remoteurl: https://ghcr.io
+  # Imagens públicas funcionam sem credenciais (token anonymous obtido
+  # automaticamente). Para imagens privadas ou rate-limit melhor,
+  # popular via secret externo e referenciar aqui (requer extensão do
+  # template configmap.yaml para ler de secret).
+  username: ""
+  password: ""
+  ttl: 168h  # 7 dias
+
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "50m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+
+nodeSelector:
+  node-role.kubernetes.io/control-plane: ""
+
+tolerations:
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Exists"
+    effect: "NoSchedule"
+
+affinity: {}
+
+config:
+  storage:
+    delete:
+      enabled: true
+    cache:
+      blobdescriptor: inmemory
+  http:
+    addr: ":5000"
+    headers:
+      X-Content-Type-Options: [nosniff]
+  health:
+    storagedriver:
+      enabled: true
+      interval: 10s
+      threshold: 3
+
+# GC mantém-se para limpar manifests órfãos do cache
+gc:
+  enabled: true
+  schedule: "0 2 * * 0"


### PR DESCRIPTION
## Summary

Adiciona `values-pullthrough-ghcr.yaml` para reconfigurar o docker-registry interno como pull-through cache de ghcr.io. Mitiga o problema de pulls flaky no node vmi3306611 sem modificar comportamento default (zero blast radius para releases existentes).

## Diagnóstico in-host (vmi3306611)

Executado via `kubectl debug node` com netshoot. Resultados refutam parcialmente hipóteses anteriores:

| Hipótese anterior | Diagnóstico |
|---|---|
| 100% ICMP loss, 50% TCP loss | **Refutado para HTTPS:** `curl https://ghcr.io` HTTP 405 em 2.3s consistente. ICMP filter no backbone é provavelmente policy. |
| MTU issue | **Refutado:** eth0 MTU 1500, pmtu 1500 |
| Backbone Contabo = root cause único | **Parcial:** tracepath morre hop 5, mas TCP retransmite |

**Causas reais identificadas:**
1. **DNS lento (2.0s lookup)** — `DNSConfigForming` warning: nameservers truncados para `213.136.95.10 213.136.95.11 1.1.1.1` (limite POSIX libc=3)
2. **Kubelet :10250 i/o timeout intermitente** — explica os 21 helm releases FAILED com "context deadline exceeded"
3. **TSO/GSO/GRO já off** — mitigação prévia activa

## Solução

Pull-through cache local elimina pulls externos repetidos:
- Imagem é puxada de ghcr.io **uma vez** pelo registry interno
- Pulls subsequentes (em qualquer node) servidos por NodePort `37.60.241.150:30500`
- Cache TTL 7 dias

## Pre-flight checks (validados)

- [x] Registry interno **sem uso activo** para push: 0 pods consomem `37.60.241.150:30500`, catálogo vazio, nenhum kaniko job a fazer push
- [x] ghcr.io org `albinojimy/neural-hive-mind`: HTTP 200 com token anonymous (public+token-auth pattern)
- [x] `helm template` gera config.yml válido com `proxy.remoteurl: https://ghcr.io`
- [x] YAML syntax validado (`yaml.safe_load` OK)
- [x] `values.yaml` e `values-ha.yaml` **não modificados** → release actual `registry/registry` continua intocado

## Trade-off documentado

⚠️ Quando `proxy.enabled: true`, o registry deixa de aceitar push (constraint do docker/distribution). Confirmado seguro: produção já migrou imagens custom para ghcr.io directamente (PR #98 confirma isto).

## Próximos passos (NÃO neste PR — operacionais)

1. **Server-side** (1 comando, baixo risco):
   ```bash
   helm upgrade registry helm-charts/docker-registry -n registry \
     -f helm-charts/docker-registry/values-pullthrough-ghcr.yaml
   ```

2. **Client-side** (todos os nodes — risco médio, requer DaemonSet ou Ansible):
   ```toml
   # /etc/containerd/certs.d/ghcr.io/hosts.toml
   server = "https://ghcr.io"
   [host."http://37.60.241.150:30500"]
     capabilities = ["pull", "resolve"]
   ```

## Out of scope (futuros PRs)

- DaemonSet para automatizar config containerd nos nodes
- Fix DNS lento (mudar primary para 1.1.1.1) — análise separada porque toca em sistema-d-resolved do host
- Adicionar 7º worker node (requer credenciais Contabo)

## Test plan

- [x] `helm template` passa
- [x] YAML válido
- [ ] CI: helm-lint
- [ ] (Pós-merge, operador) `helm upgrade --dry-run` antes do upgrade real
- [ ] (Pós-upgrade) `curl http://37.60.241.150:30500/v2/_catalog` retorna lista
- [ ] (Pós-containerd-config) `crictl pull ghcr.io/.../approval-service:05ca2b2` num node usa mirror

Refs: análise consolidada do diagnóstico em comentário no PR #98 e nas memórias do projecto.

Co-Authored-By: Claude Opus 4.7 (1M context)