### PR TITLE
fix(TR-2): unblock worker fleet via Gatekeeper labels + pre-flight + runbook

### DIFF
--- a/docs/runbooks/worker-fleet-reactivation.md
+++ b/docs/runbooks/worker-fleet-reactivation.md
@@ -1,0 +1,262 @@
+# Runbook — Worker Fleet Reactivation (TR-2)
+
+> Spec: `.agent-os/specs/2026-05-22-pipeline-flow-recovery/` (TR-2)
+> Depende de: TR-1 (Queen Redis cluster) estável em produção
+
+## Contexto
+
+Os 6 deployments da worker fleet (`worker-agents`, `analyst-agents`,
+`guard-agents`, `optimizer-agents`, `scout-agents`,
+`self-healing-engine`) estão em `0/0` desired há ≥132 dias. Pipeline
+downstream do Orchestrator (Flow D) não pode executar tickets.
+
+**Causa raiz identificada:** os pod templates não declaravam as labels
+exigidas pelo Gatekeeper constraint `neural-hive-pod-labels` (`app`,
+`component`, `version`). Cada `kubectl scale --replicas=N` falhava
+silenciosamente no admission webhook → deploy ficava em `0/N`.
+
+Este PR/branch corrigiu os charts. O runbook abaixo guia a reactivação
+incremental.
+
+---
+
+## Pré-requisitos
+
+1. **TR-1 merged e queen-agent estável em runtime:**
+   ```bash
+   kubectl logs -n neural-hive deploy/queen-agent --since=10m | grep CLUSTERDOWN | wc -l
+   # Deve devolver 0.
+   ```
+
+2. **Pre-flight check passa:**
+   ```bash
+   python3 scripts/tr2_preflight_check.py
+   echo "Exit code: $?"   # Esperado: 0
+   ```
+
+3. **Imagens GHCR existem** (rápido, sem cluster):
+   ```bash
+   for chart in worker-agents analyst-agents guard-agents \
+                optimizer-agents scout-agents self-healing-engine; do
+     img=$(yq '.image.repository + ":" + .image.tag' helm-charts/$chart/values.yaml)
+     echo "Verificando $img..."
+     docker manifest inspect "$img" >/dev/null 2>&1 && echo "  OK" || echo "  MISSING"
+   done
+   ```
+
+4. **ConfigMaps + Secrets já existem** no ns `neural-hive` (criados em
+   deploys anteriores; Flux mantém-nos):
+   ```bash
+   kubectl -n neural-hive get cm,secret | grep -E "worker-agents|analyst-agents|guard-agents|optimizer-agents|scout-agents|self-healing-engine"
+   ```
+
+5. **Capacidade do cluster:** os 6 deployments somam um pico de ~30 pods
+   (HPA max). Validar headroom de CPU/memória:
+   ```bash
+   kubectl top nodes
+   kubectl describe nodes | grep -A5 "Allocated resources"
+   ```
+
+---
+
+## Sequência de execução
+
+### Justificativa da ordem
+
+A ordem é deliberada: `optimizer → scout → analyst → guard → worker →
+self-healing-engine`. Razões:
+
+- **`optimizer-agents` primeiro:** menor blast-radius, 1 réplica
+  apenas. Validar conectividade Kafka/Redis sem comprometer outros
+  workers.
+- **`self-healing-engine` por último:** componente de auto-remediação
+  dos restantes workers. Se entrar primeiro com política agressiva,
+  pode reiniciar pods que estão intencionalmente a 0/N ou interferir
+  com o scale-up incremental. Durante as janelas de smoke 30 min dos
+  primeiros 5 workers, **o operador é a única salvaguarda** —
+  monitorar manualmente os critérios de continuação.
+
+Ordem do scale-up (do menor risco para o maior, com smoke 30min entre
+cada — spec TR-2 subtasks 3.2–3.7):
+
+| # | Deployment | Réplicas alvo | Smoke duration |
+|---|---|---|---|
+| 1 | `optimizer-agents` | 1 | 30 min |
+| 2 | `scout-agents` | 2 | 30 min |
+| 3 | `analyst-agents` | 2 | 30 min |
+| 4 | `guard-agents` | 2 | 30 min |
+| 5 | `worker-agents` | 2 | 30 min |
+| 6 | `self-healing-engine` | 2 | 30 min |
+
+### Para CADA deployment
+
+**1. Scale-up:**
+```bash
+kubectl scale -n neural-hive deploy/<DEPLOYMENT> --replicas=<N>
+```
+
+**2. Aguardar pods Ready:**
+```bash
+kubectl -n neural-hive rollout status deploy/<DEPLOYMENT> --timeout=5m
+```
+
+**3. Validar Kafka registration nos logs:**
+```bash
+kubectl -n neural-hive logs deploy/<DEPLOYMENT> --since=2m \
+  | grep -iE "kafka.*connected|consumer.*group|service-registry.*registered"
+# Esperado: pelo menos uma entrada de cada padrão.
+```
+
+**4. Smoke test 30 min — janela de observação:**
+```bash
+# Em loop, a cada 5 min:
+kubectl -n neural-hive get pod -l app=<DEPLOYMENT> -o wide
+kubectl -n neural-hive top pod -l app=<DEPLOYMENT>
+kubectl -n neural-hive logs deploy/<DEPLOYMENT> --since=5m \
+  | grep -iE "error|exception|circuit.*open" | head
+```
+
+**5. Critérios de continuação:** se durante 30 min consecutivos:
+   - `RESTARTS = 0` em todos os pods
+   - Zero `error|exception` críticos nos logs
+   - Memória < 80% do limit
+   - CPU < 80% do limit
+
+   → avançar para o próximo deployment.
+
+**6. Rollback trigger:** se qualquer critério acima falhar:
+```bash
+kubectl scale -n neural-hive deploy/<DEPLOYMENT> --replicas=0
+# Investigar logs e métricas; voltar a este runbook apenas após
+# entender a causa raiz.
+```
+
+---
+
+## Validação E2E final (subtask 3.8)
+
+Após os 6 deployments scaled e estáveis 30min cada:
+
+**1. Injectar 5 test intents via Gateway:**
+```bash
+for i in $(seq 1 5); do
+  curl -X POST https://gateway.neural-hive.local/api/v1/intent \
+    -H "Content-Type: application/json" \
+    -d "{\"text\": \"Test intent $i — E2E smoke\", \"priority\": \"low\"}"
+done
+```
+
+**2. Validar `execution.tickets` recebe ≥5 messages:**
+```bash
+# Consumer group ID vem do ConfigMap (configurável via
+# helm-charts/worker-agents/values.yaml::config.kafka.consumerGroup).
+GROUP=$(kubectl -n neural-hive get cm worker-agents-config \
+  -o jsonpath='{.data.KAFKA_CONSUMER_GROUP}')
+kubectl -n kafka exec -it neural-hive-kafka-0 -- \
+  kafka-consumer-groups.sh --bootstrap-server localhost:9092 \
+  --group "${GROUP:-worker-agents}" --describe
+# Coluna LOG-END-OFFSET deve ter incrementado em pelo menos 5.
+```
+
+**3. Validar `execution.results` recebe ≥5 messages:**
+```bash
+kubectl -n kafka exec -it neural-hive-kafka-0 -- \
+  kafka-console-consumer.sh --bootstrap-server localhost:9092 \
+  --topic execution.results --from-beginning --max-messages 5 --timeout-ms 60000
+```
+
+**4. HPA targets numéricos (não `<unknown>`):**
+```bash
+kubectl -n neural-hive get hpa
+# Coluna TARGETS deve ter percentagens ou valores absolutos, não `<unknown>`.
+```
+
+---
+
+## Métricas-chave
+
+| Métrica | Threshold | Onde |
+|---|---|---|
+| `kube_pod_container_status_restarts_total{namespace="neural-hive",pod=~"<deployment>.*"}` | == 0 (1h) | Grafana |
+| `kafka_consumergroup_lag{group="worker-agents",topic="execution.tickets"}` | < 10 sustained | Grafana |
+| `container_memory_working_set_bytes / container_spec_memory_limit_bytes` | < 0.8 | Grafana |
+| `rate(container_cpu_usage_seconds_total[5m]) / container_spec_cpu_quota` | < 0.8 | Grafana |
+
+---
+
+## Riscos conhecidos
+
+1. **Imagens antigas (≥100 dias):** se houve mudanças incompatíveis no
+   resto do stack durante este período (proto schemas, Kafka topics
+   renomeados, env vars), pods podem entrar em CrashLoopBackOff.
+   Mitigação: escalonamento incremental + smoke 30min antes do próximo.
+
+2. **CPU saturation Contabo:** o cluster está em nós shared-vCPU.
+   30 pods novos × ~200m CPU request = 6 vCPU adicionais. Validar
+   `kubectl top nodes` antes de cada step.
+
+3. **Kafka consumer-group rebalances:** scale-up de N consumers no
+   mesmo grupo dispara N rebalances. Pode haver janela de 30-60s sem
+   consumo enquanto rebalance corre.
+
+4. **Gatekeeper drift:** se a constraint
+   `neural-hive-pod-labels` for actualizada (adicionar labels), este
+   fix de TR-2 ficará incompleto. Re-correr o pre-flight check.
+
+5. **PDB `minAvailable: 1` em workloads a 0/N (`worker-agents`,
+   `guard-agents`, `scout-agents`, `self-healing-engine`):** com 0
+   réplicas, o constraint `minAvailable: 1` é estruturalmente
+   impossível. A eviction API (`kubectl drain`, cluster autoscaler,
+   Flux reconcile) recusa evictions de pods nos nós onde estes
+   workloads pretendem estar — bloqueia node-drains até o workload
+   ter ≥1 pod Running. **Não agendar manutenção de nós durante a
+   execução de TR-2.** `kubectl rollout status` não detecta isto;
+   só sinais externos (drain stuck, alertas Flux) o revelam.
+
+6. **Outros charts em `neural-hive` ainda não-compliant com
+   `neural-hive-pod-labels`:** este PR só corrigiu os 6 worker charts.
+   `approval-service`, `consensus-engine` e restantes ainda usam só
+   `app.kubernetes.io/*` (sem labels bare `app`/`component`/`version`).
+   **Não disparar re-deploys destes serviços durante TR-2** — o
+   Gatekeeper rejeitaria a criação dos pods (constraint default action
+   é `deny`). Ticket separado para alinhar todos os charts.
+
+7. **`schemaRegistryUrl: ""` no `worker-agents`
+   (JSON fallback):** o values.yaml tem um TODO "Desabilitado para
+   forçar fallback JSON (mensagens antigas em JSON)". Se a pipeline
+   upstream (STE, orchestrator) entretanto migrou para Avro nos
+   tópicos `execution.tickets` ou `execution.results`, o `worker-agents`
+   vai crash-loop em deserialização. **Antes do step 5 (scale
+   worker-agents), validar o formato actual das mensagens:**
+   ```bash
+   kubectl -n kafka exec -it neural-hive-kafka-0 -- \
+     kafka-console-consumer.sh --bootstrap-server localhost:9092 \
+     --topic execution.tickets --max-messages 1 --timeout-ms 10000 \
+     --from-beginning | head -c 100
+   ```
+   Se a saída começar por `{` (JSON) → OK. Se começar por bytes
+   binários (Avro magic byte `0x00`) → **ABORT scale-up** e abrir
+   ticket para migrar `worker-agents` para Avro consumer.
+
+---
+
+## Critérios de aceitação TR-2 (spec)
+
+- [ ] `kubectl get hpa -n neural-hive` mostra TARGETS numérico (não
+      `<unknown>`) para os 6 HPAs.
+- [ ] `kafka-consumer-groups --describe --group worker-agents` mostra
+      LAG = 0 em `execution.tickets` após injectar 5 test intents.
+- [ ] `kubectl logs deploy/<each-worker> --since=1h | grep -iE
+      "CrashLoop|OOMKill"` retorna 0 entradas.
+- [ ] `execution.results` recebe ≥5 messages após injecção.
+
+---
+
+## Referências
+
+- Spec: `.agent-os/specs/2026-05-22-pipeline-flow-recovery/spec.md`
+- Technical spec: `.agent-os/specs/2026-05-22-pipeline-flow-recovery/sub-specs/technical-spec.md`
+- Pre-flight script: `scripts/tr2_preflight_check.py`
+- Constraints Gatekeeper: `gatekeeper/constraints/neural-hive-constraints.yaml`
+- PR TR-1 (dependência): #102
+- PR TR-4 (independente): #101

--- a/helm-charts/analyst-agents/templates/hpa.yaml
+++ b/helm-charts/analyst-agents/templates/hpa.yaml
@@ -1,0 +1,54 @@
+{{- /*
+TR-2 (spec 2026-05-22-pipeline-flow-recovery): chart `analyst-agents`
+não tinha HPA, divergindo dos restantes 5 workers e contradizendo o
+critério de aceitação da spec (`kubectl get hpa -n neural-hive` mostra
+TARGETS numérico para os 6 HPAs). Adicionado por simetria com os outros
+charts (worker-agents, guard-agents, optimizer-agents, scout-agents,
+self-healing-engine), todos usando `autoscaling.*` do values.yaml.
+*/}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "analyst-agents.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "analyst-agents.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "analyst-agents.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 30
+{{- end }}

--- a/helm-charts/analyst-agents/values.yaml
+++ b/helm-charts/analyst-agents/values.yaml
@@ -1,6 +1,15 @@
 component: "analyst-agents"
 layer: "analise"
 
+# TR-2: labels exigidas pelo Gatekeeper constraint
+# `neural-hive-pod-labels` (ver helm-charts/worker-agents/values.yaml
+# para contexto). Sem estas labels, criação de pods em ns `neural-hive`
+# é rejeitada e o deploy fica em 0/0.
+podLabels:
+  app: analyst-agents
+  component: analyst-agents
+  version: "1.2.1"
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/helm-charts/guard-agents/values.yaml
+++ b/helm-charts/guard-agents/values.yaml
@@ -1,6 +1,12 @@
 component: "guard-agents"
 layer: "resilience"
 
+# TR-2: labels Gatekeeper-compliant para ns `neural-hive`.
+podLabels:
+  app: guard-agents
+  component: guard-agents
+  version: "1.2.0"
+
 image:
   repository: ghcr.io/albinojimy/neural-hive-mind/guard-agents
   tag: "1.2.0"

--- a/helm-charts/optimizer-agents/values.yaml
+++ b/helm-charts/optimizer-agents/values.yaml
@@ -1,6 +1,12 @@
 component: "optimizer-agents"
 layer: "otimizacao"
 
+# TR-2: labels Gatekeeper-compliant para ns `neural-hive`.
+podLabels:
+  app: optimizer-agents
+  component: optimizer-agents
+  version: "1.2.1"
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/helm-charts/scout-agents/values.yaml
+++ b/helm-charts/scout-agents/values.yaml
@@ -1,6 +1,12 @@
 component: "scout-agents"
 layer: "exploration"
 
+# TR-2: labels Gatekeeper-compliant para ns `neural-hive`.
+podLabels:
+  app: scout-agents
+  component: scout-agents
+  version: "1.2.0"
+
 serviceAccount:
   create: true
   name: ""

--- a/helm-charts/self-healing-engine/values.yaml
+++ b/helm-charts/self-healing-engine/values.yaml
@@ -199,6 +199,12 @@ podLabels:
   app.kubernetes.io/component: self-healing
   neural-hive.io/layer: resilience
   neural-hive.io/domain: remediation
+  # TR-2: labels Gatekeeper-compliant para ns `neural-hive`
+  # (app.kubernetes.io/* não satisfaz o constraint que pede labels
+  # bare `app`, `component`, `version`).
+  app: self-healing-engine
+  component: self-healing-engine
+  version: "1.2.0"
 
 serviceMonitor:
   enabled: false

--- a/helm-charts/worker-agents/values.yaml
+++ b/helm-charts/worker-agents/values.yaml
@@ -1,6 +1,16 @@
 component: "worker-agents"
 layer: "execution"
 
+# TR-2 (spec 2026-05-22-pipeline-flow-recovery): labels exigidas pelo
+# Gatekeeper constraint `neural-hive-pod-labels` em ns `neural-hive`.
+# Antes deste fix, criação de pods era rejeitada → deploy ficava em 0/0.
+# `app.kubernetes.io/*` standard NÃO satisfaz o constraint; este define
+# os labels `app`, `component`, `version` explicitamente.
+podLabels:
+  app: worker-agents
+  component: worker-agents
+  version: "1.3.4"
+
 serviceAccount:
   create: true
   name: ""

--- a/scripts/tr2_preflight_check.py
+++ b/scripts/tr2_preflight_check.py
@@ -1,0 +1,299 @@
+"""
+TR-2 pre-flight: valida que os Helm charts dos 6 workers estão prontos
+para reactivação (scale-up de 0 → minReplicas do HPA).
+
+Spec: `.agent-os/specs/2026-05-22-pipeline-flow-recovery/` (TR-2).
+
+Verifica (dry-run, sem cluster):
+  1. Helm template renderiza sem erros (chart estruturalmente válido)
+  2. Pod template inclui labels exigidas pelo Gatekeeper constraint
+     `neural-hive-pod-labels` (`app`, `component`, `version`)
+  3. Service inclui labels exigidas por `neural-hive-service-labels`
+     (`app`, `component`, `part-of`, `managed-by`)
+  4. Imagem GHCR está bem-formada (`ghcr.io/<org>/<repo>:<tag>`)
+  5. HPA está presente quando esperado, com `minReplicas >= 1`
+
+Output: JSON estruturado em stdout. Exit code 0 = todos OK, 1 = falhas.
+
+Uso:
+    python3 scripts/tr2_preflight_check.py [--chart-dir helm-charts] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# Spec TR-2: lista dos 6 workers a reactivar. A ordem importa para o
+# runbook (scale incremental com smoke 30min entre cada).
+WORKERS = [
+    "optimizer-agents",
+    "scout-agents",
+    "analyst-agents",
+    "guard-agents",
+    "worker-agents",
+    "self-healing-engine",
+]
+
+# Labels exigidas pelos Gatekeeper constraints no ns `neural-hive`
+# (ver gatekeeper/constraints/neural-hive-constraints.yaml).
+REQUIRED_POD_LABELS: tuple[str, ...] = ("app", "component", "version")
+REQUIRED_SERVICE_LABELS: tuple[str, ...] = ("app", "component", "part-of", "managed-by")
+
+GHCR_IMAGE_PREFIX = "ghcr.io/"
+
+
+@dataclass
+class CheckResult:
+    chart: str
+    ok: bool = True
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    details: dict[str, object] = field(default_factory=dict)
+
+    def fail(self, msg: str) -> None:
+        self.ok = False
+        self.errors.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+
+def render_chart(chart_path: Path) -> list[dict]:
+    """Renderiza chart via `helm template` e devolve lista de docs YAML.
+
+    Levanta RuntimeError em falha de render — apanhada pelo caller para
+    fazer downgrade a check error.
+    """
+    helm = shutil.which("helm")
+    if not helm:
+        raise RuntimeError("helm binary não disponível no PATH")
+
+    # Args são strings literais + chart_path (não-tainted), exec via list
+    # (sem shell). Sem injection surface.
+    result = subprocess.run(
+        [helm, "template", "test", str(chart_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"helm template falhou: {result.stderr.strip()}")
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def _check_pod_labels(deployment: dict, result: CheckResult) -> None:
+    labels = deployment.get("spec", {}).get("template", {}).get("metadata", {}).get("labels", {})
+    missing = [k for k in REQUIRED_POD_LABELS if k not in labels]
+    if missing:
+        result.fail(
+            f"Pod template não tem labels Gatekeeper-compliant: missing={missing}. "
+            "Adiciona-as a `podLabels` no values.yaml. Sem isto, o Gatekeeper "
+            "rejeita a criação do pod e o scale-up fica preso em 0/N."
+        )
+    else:
+        result.details["pod_labels"] = {k: labels[k] for k in REQUIRED_POD_LABELS}
+
+
+def _check_service_labels(service: dict, result: CheckResult) -> None:
+    labels = service.get("metadata", {}).get("labels", {}) or {}
+    missing = [k for k in REQUIRED_SERVICE_LABELS if k not in labels]
+    if missing:
+        result.warn(
+            f"Service `{service.get('metadata', {}).get('name')}` não tem todas as "
+            f"labels exigidas por neural-hive-service-labels: missing={missing}. "
+            "Não bloqueia scale-up dos pods mas viola constraint do ns."
+        )
+
+
+def _check_image_reference(deployment: dict, result: CheckResult) -> None:
+    containers = (
+        deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    )
+    if not containers:
+        result.fail("Deployment não tem containers definidos.")
+        return
+
+    main = containers[0]
+    image = main.get("image", "")
+    if not image.startswith(GHCR_IMAGE_PREFIX):
+        result.warn(
+            f"Imagem `{image}` não é do GHCR ({GHCR_IMAGE_PREFIX}*). Confirma "
+            "que o registry é acessível a partir do cluster."
+        )
+    if ":" not in image.split("/")[-1]:
+        result.fail(
+            f"Imagem `{image}` sem tag explícita — risco de pull não-determinístico. "
+            "Especifica `image.tag` no values.yaml."
+        )
+    else:
+        result.details["image"] = image
+
+
+def _check_version_label_matches_image(deployment: dict, result: CheckResult) -> None:
+    """Detecta drift entre `podLabels.version` e `image.tag`.
+
+    `podLabels.version` é mantido manualmente no values.yaml; ferramentas
+    de automação (Flux, Renovate) actualizam `image.tag` mas não a
+    label. Se a label ficar stale, dashboards de observabilidade que
+    filtram por `version=` mostram dados de versão errada.
+    """
+    pod_labels = (
+        deployment.get("spec", {}).get("template", {}).get("metadata", {}).get("labels", {})
+    )
+    containers = (
+        deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    )
+    if not containers:
+        return
+
+    label_version = pod_labels.get("version")
+    image = containers[0].get("image", "")
+    # Extrair tag da forma `repo:tag` (último `:` após o último `/`).
+    image_tag = image.rsplit(":", 1)[-1] if ":" in image.rsplit("/", 1)[-1] else None
+
+    if label_version and image_tag and label_version != image_tag:
+        result.warn(
+            f"podLabels.version='{label_version}' diverge de image.tag='{image_tag}'. "
+            "Actualizá-los em sincronia ou derivar a label do tag no template."
+        )
+
+
+def _check_hpa(docs: list[dict], chart: str, result: CheckResult) -> None:
+    hpas = [d for d in docs if d.get("kind") == "HorizontalPodAutoscaler"]
+    if not hpas:
+        # Sem HPA, o scale-up manual via `kubectl scale --replicas=N`
+        # ainda é viável, mas perde-se auto-scaling em runtime e o
+        # critério de aceitação `kubectl get hpa` mostra um deployment
+        # sem entrada — falha implicita no spec gate.
+        result.warn(
+            f"Chart `{chart}` não define HPA. Scale-up manual via "
+            "`kubectl scale --replicas=N` é viável; sem HPA não há "
+            "auto-scaling em runtime."
+        )
+        return
+
+    hpa = hpas[0]
+    min_replicas = hpa.get("spec", {}).get("minReplicas", 0)
+    if min_replicas < 1:
+        result.fail(
+            f"HPA tem minReplicas={min_replicas}. Para reactivação, "
+            "minReplicas >= 1 é obrigatório."
+        )
+    result.details["hpa_min_replicas"] = min_replicas
+    result.details["hpa_max_replicas"] = hpa.get("spec", {}).get("maxReplicas")
+
+
+def check_chart(chart_path: Path) -> CheckResult:
+    result = CheckResult(chart=chart_path.name)
+
+    try:
+        docs = render_chart(chart_path)
+    except RuntimeError as exc:
+        result.fail(str(exc))
+        return result
+
+    deployments = [d for d in docs if d.get("kind") == "Deployment"]
+    services = [d for d in docs if d.get("kind") == "Service"]
+
+    if not deployments:
+        result.fail("Chart não produz Deployment.")
+        return result
+
+    # Iterar TODOS os Deployments — alguns charts podem ter side-cars,
+    # canary, ou init deployments além do principal. Aceitar só `[0]`
+    # mascarava falhas em qualquer um adicional.
+    for dep in deployments:
+        _check_pod_labels(dep, result)
+        _check_image_reference(dep, result)
+    _check_version_label_matches_image(deployments[0], result)
+    for svc in services:
+        _check_service_labels(svc, result)
+    _check_hpa(docs, chart_path.name, result)
+
+    return result
+
+
+def run(chart_dir: Path, workers: list[str]) -> tuple[list[CheckResult], int]:
+    results: list[CheckResult] = []
+    for worker in workers:
+        chart_path = chart_dir / worker
+        if not chart_path.exists():
+            r = CheckResult(chart=worker)
+            r.fail(f"Chart não encontrado em {chart_path}")
+            results.append(r)
+            continue
+        results.append(check_chart(chart_path))
+
+    exit_code = 0 if all(r.ok for r in results) else 1
+    return results, exit_code
+
+
+def _format_human(results: list[CheckResult]) -> str:
+    lines = []
+    for r in results:
+        status = "OK" if r.ok and not r.warnings else ("WARN" if r.ok else "FAIL")
+        lines.append(f"[{status}] {r.chart}")
+        for err in r.errors:
+            lines.append(f"  ERROR: {err}")
+        for warn in r.warnings:
+            lines.append(f"  WARN:  {warn}")
+        if r.details:
+            for k, v in r.details.items():
+                lines.append(f"  {k}: {v}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--chart-dir",
+        type=Path,
+        default=Path("helm-charts"),
+        help="Directório que contém os charts (default: helm-charts)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON em vez de human-readable",
+    )
+    parser.add_argument(
+        "--workers",
+        nargs="*",
+        default=WORKERS,
+        help="Subset de workers a verificar (default: todos os 6)",
+    )
+    args = parser.parse_args(argv)
+
+    results, exit_code = run(args.chart_dir.resolve(), args.workers)
+
+    if args.json:
+        payload = {
+            "ok": exit_code == 0,
+            "results": [
+                {
+                    "chart": r.chart,
+                    "ok": r.ok,
+                    "errors": r.errors,
+                    "warnings": r.warnings,
+                    "details": r.details,
+                }
+                for r in results
+            ],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_format_human(results))
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_tr2_preflight.py
+++ b/tests/unit/test_tr2_preflight.py
@@ -1,0 +1,274 @@
+"""
+Testes unitários para `scripts/tr2_preflight_check.py`.
+
+Foco: lógica de verificação por chart (pod labels Gatekeeper, image
+reference, HPA presence), com manifests sintéticos injectados via
+monkeypatch de `render_chart` — não invocam o binário `helm`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Carregar o script como módulo (não é um package — está em scripts/).
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "tr2_preflight_check.py"
+spec = importlib.util.spec_from_file_location("tr2_preflight_check", SCRIPT_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Não consigo carregar {SCRIPT_PATH}")
+tr2 = importlib.util.module_from_spec(spec)
+sys.modules["tr2_preflight_check"] = tr2
+spec.loader.exec_module(tr2)
+
+
+def _deployment(
+    pod_labels: dict | None = None,
+    image: str = "ghcr.io/test/svc:1.0.0",
+    containers: list | None = None,
+) -> dict:
+    """Constrói um Deployment YAML dict sintético."""
+    if containers is None:
+        containers = [{"name": "svc", "image": image}]
+    return {
+        "kind": "Deployment",
+        "metadata": {"name": "test"},
+        "spec": {
+            "template": {
+                "metadata": {"labels": pod_labels or {}},
+                "spec": {"containers": containers},
+            },
+        },
+    }
+
+
+def _hpa(min_replicas: int = 2, max_replicas: int = 10) -> dict:
+    return {
+        "kind": "HorizontalPodAutoscaler",
+        "spec": {"minReplicas": min_replicas, "maxReplicas": max_replicas},
+    }
+
+
+def _service(labels: dict | None = None) -> dict:
+    return {
+        "kind": "Service",
+        "metadata": {"name": "svc", "labels": labels or {}},
+    }
+
+
+def _gatekeeper_compliant_labels() -> dict:
+    return {"app": "svc", "component": "svc", "version": "1.0.0"}
+
+
+def _full_service_labels() -> dict:
+    return {
+        "app": "svc",
+        "component": "svc",
+        "part-of": "neural-hive-mind",
+        "managed-by": "Helm",
+    }
+
+
+def test_check_chart_ok_when_all_labels_present(monkeypatch, tmp_path):
+    docs = [_deployment(_gatekeeper_compliant_labels()), _service(_full_service_labels()), _hpa()]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is True
+    assert result.errors == []
+    assert result.warnings == []
+
+
+def test_check_chart_fails_missing_pod_labels(monkeypatch, tmp_path):
+    docs = [_deployment({"app.kubernetes.io/name": "svc"}), _hpa()]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is False
+    assert any("Gatekeeper-compliant" in err for err in result.errors)
+    assert any("missing=" in err for err in result.errors)
+
+
+def test_check_chart_fails_no_deployment(monkeypatch, tmp_path):
+    """Chart sem Deployment é unactionable."""
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: [_service(_full_service_labels())])
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is False
+    assert "Deployment" in result.errors[0]
+
+
+def test_check_chart_fails_image_without_tag(monkeypatch, tmp_path):
+    docs = [_deployment(_gatekeeper_compliant_labels(), image="ghcr.io/test/svc"), _hpa()]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is False
+    assert any("sem tag explícita" in err for err in result.errors)
+
+
+def test_check_chart_warns_non_ghcr_image(monkeypatch, tmp_path):
+    docs = [
+        _deployment(_gatekeeper_compliant_labels(), image="docker.io/test/svc:1.0"),
+        _hpa(),
+    ]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is True
+    assert any("não é do GHCR" in w for w in result.warnings)
+
+
+def test_check_chart_warns_when_hpa_absent(monkeypatch, tmp_path):
+    docs = [_deployment(_gatekeeper_compliant_labels()), _service(_full_service_labels())]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is True
+    assert any("não define HPA" in w for w in result.warnings)
+
+
+def test_check_chart_fails_hpa_min_replicas_zero(monkeypatch, tmp_path):
+    docs = [_deployment(_gatekeeper_compliant_labels()), _hpa(min_replicas=0)]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is False
+    assert any("minReplicas=0" in err for err in result.errors)
+
+
+def test_check_chart_warns_service_missing_labels(monkeypatch, tmp_path):
+    docs = [
+        _deployment(_gatekeeper_compliant_labels()),
+        _service({"app": "svc"}),  # falta component/part-of/managed-by
+        _hpa(),
+    ]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is True  # service labels são warning, não error
+    assert any("neural-hive-service-labels" in w for w in result.warnings)
+
+
+def test_check_chart_fails_when_render_raises(monkeypatch, tmp_path):
+    def _explode(_p):
+        raise RuntimeError("helm template failed: invalid template")
+
+    monkeypatch.setattr(tr2, "render_chart", _explode)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is False
+    assert "helm template failed" in result.errors[0]
+
+
+def test_check_chart_warns_on_version_label_drift(monkeypatch, tmp_path):
+    """CR-002: detectar drift entre podLabels.version e image.tag."""
+    labels = {"app": "svc", "component": "svc", "version": "1.0.0"}
+    docs = [
+        _deployment(labels, image="ghcr.io/test/svc:2.0.0"),  # tag != label
+        _hpa(),
+    ]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is True  # drift é warning, não error
+    assert any("diverge de image.tag" in w for w in result.warnings)
+
+
+def test_check_chart_no_warning_when_version_matches_image(monkeypatch, tmp_path):
+    """CR-002 (negative): sem drift, nenhum warning de version."""
+    labels = {"app": "svc", "component": "svc", "version": "1.0.0"}
+    docs = [_deployment(labels, image="ghcr.io/test/svc:1.0.0"), _hpa()]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert not any("diverge de image.tag" in w for w in result.warnings)
+
+
+def test_check_chart_iterates_multiple_deployments(monkeypatch, tmp_path):
+    """CR-004: chart com 2 Deployments, segundo sem labels → falha registada."""
+    docs = [
+        _deployment({"app": "svc", "component": "svc", "version": "1.0.0"}),
+        _deployment({"app.kubernetes.io/name": "svc"}),  # sem bare labels → fail
+        _hpa(),
+    ]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    result = tr2.check_chart(tmp_path / "svc")
+
+    assert result.ok is False
+    assert any("Gatekeeper-compliant" in err for err in result.errors)
+
+
+def test_run_returns_exit_1_on_any_failure(monkeypatch, tmp_path):
+    """Se um único chart falha, o exit code agregado é 1."""
+    monkeypatch.setattr(
+        tr2,
+        "render_chart",
+        lambda p: (
+            [_deployment(_gatekeeper_compliant_labels()), _hpa()]
+            if "ok-chart" in str(p)
+            else [_deployment({})]  # sem labels → fail
+        ),
+    )
+    (tmp_path / "ok-chart").mkdir()
+    (tmp_path / "broken-chart").mkdir()
+
+    results, exit_code = tr2.run(tmp_path, ["ok-chart", "broken-chart"])
+
+    assert exit_code == 1
+    assert results[0].ok is True
+    assert results[1].ok is False
+
+
+def test_run_returns_exit_0_when_all_ok(monkeypatch, tmp_path):
+    docs = [_deployment(_gatekeeper_compliant_labels()), _service(_full_service_labels()), _hpa()]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+
+    chart_dir = tmp_path
+    for name in ("a", "b", "c"):
+        (chart_dir / name).mkdir()
+
+    results, exit_code = tr2.run(chart_dir, ["a", "b", "c"])
+
+    assert exit_code == 0
+    assert all(r.ok for r in results)
+    assert all(r.warnings == [] for r in results)
+
+
+def test_run_handles_missing_chart_dir(tmp_path):
+    """Worker listado mas chart não existe → falha registada."""
+    results, exit_code = tr2.run(tmp_path, ["nonexistent"])
+
+    assert exit_code == 1
+    assert results[0].ok is False
+    assert "não encontrado" in results[0].errors[0]
+
+
+def test_json_output_when_flag_present(monkeypatch, tmp_path, capsys):
+    docs = [_deployment(_gatekeeper_compliant_labels()), _hpa()]
+    monkeypatch.setattr(tr2, "render_chart", lambda _p: docs)
+    (tmp_path / "svc").mkdir()
+
+    import json
+
+    exit_code = tr2.main(["--chart-dir", str(tmp_path), "--json", "--workers", "svc"])
+    captured = capsys.readouterr().out
+
+    assert exit_code == 0
+    payload = json.loads(captured)
+    assert payload["ok"] is True
+    assert payload["results"][0]["chart"] == "svc"
+    assert payload["results"][0]["ok"] is True


### PR DESCRIPTION
## Summary

Resolve a causa-raiz da inactividade da worker fleet (6 deployments em `0/0` há ≥132 dias) — os pod templates não tinham labels `app`, `component`, `version` exigidos pelo Gatekeeper constraint `neural-hive-pod-labels`. Cada `kubectl scale --replicas=N` ficava em `0/N` silenciosamente porque o admission webhook rejeitava os pods. Mapeia directamente para as "46 violações must-have-app-label-all" da spec. Ticket **TR-2** do spec [`2026-05-22-pipeline-flow-recovery`](https://github.com/albinoJimy/Neural-Hive-Mind/pull/101).

## Root cause

```yaml
# Constraint Gatekeeper exige labels bare:
parameters:
  labels: ["app", "component", "version"]
# Pod templates só tinham app.kubernetes.io/*:
labels:
  app.kubernetes.io/name: worker-agents
  app.kubernetes.io/instance: test
# → admission rejeitada silenciosamente
```

## Changes

### Charts (6 × `values.yaml`)
Cada chart ganha `podLabels:` com `app`/`component`/`version`. Template comum `neural-hive.deployment` já propaga `$values.podLabels` — sem mudança no template.

### `helm-charts/analyst-agents/templates/hpa.yaml` (novo)
Único chart sem HPA, contradizendo o critério `kubectl get hpa` mostra TARGETS numérico para os 6 workers (GAP-4 auditoria). HPA replica estrutura de `optimizer-agents`.

### `scripts/tr2_preflight_check.py` (novo)
Pre-flight Python dry-run (sem cluster) que valida via `helm template`:
- chart estruturalmente válido
- pod template tem labels Gatekeeper-compliant
- imagem é GHCR com tag explícita
- HPA presente, `minReplicas >= 1`
- service labels (warn-level)
- `podLabels.version == image.tag` (drift detection — CR-002 auditoria)
- itera TODOS os deployments (CR-004 auditoria)

Output human-readable ou JSON. Exit 0/1. Pre-flight contra os 6 charts pós-fix: **6/6 PASS** (apenas warnings sobre service labels).

### `tests/unit/test_tr2_preflight.py` (16 tests pass)
Cobertura completa: happy path, missing labels, image sem tag, HPA absent/min=0, drift version, multi-deployment, JSON output, render exception.

### `docs/runbooks/worker-fleet-reactivation.md` (novo)
Procedimento operacional para executar pós-merge:
- Pré-requisitos (TR-1 estável, pre-flight pass, imagens GHCR, capacidade)
- Ordem scale-up justificada: `optimizer → scout → analyst → guard → worker → self-healing`
- Por deployment: scale, rollout, log checks, smoke 30min, critérios
- E2E validation (5 test intents, execution.tickets, execution.results)
- Métricas-chave Prometheus
- 7 riscos documentados (incluindo PDB minAvailable=1, Avro/JSON schema, outros charts neural-hive não-compliant)

## Audit pipeline

Duas auditorias paralelas (qualidade + completude):

| Verdict | Issues | Remediados | Documentados |
|---|---|---|---|
| Code reviewer | 0 CRIT, 5 WARN, 4 INFO | CR-002, CR-004, CR-005, CR-007, CR-008 | CR-001, CR-003, CR-006, CR-009 (runbook + PR) |
| Gap analyzer | 5 gaps (2 ALTA, 1 MED, 2 BAIXA) | GAP-4 (HPA analyst-agents), GAP-5 (commit) | GAP-1 GAP-2 GAP-3 (PR description) |

## Testing

**16/16 unit tests pass** — `tests/unit/test_tr2_preflight.py`.
**Pre-flight live**: `python3 scripts/tr2_preflight_check.py` → exit 0.
**Helm render**: 6 charts produzem pods com `app/component/version` labels confirmados.
**Lint**: ruff + black clean.

## Subtasks status (TR-2 em tasks.md)

| Subtask | Status |
|---|---|
| 3.1 Auditoria pré-flight | ✅ `scripts/tr2_preflight_check.py` |
| 3.2 Scale optimizer + smoke 30min | ⏳ **Operacional pós-merge** (runbook) |
| 3.3 Scale scout + smoke 30min | ⏳ Operacional |
| 3.4 Scale analyst + smoke 30min | ⏳ Operacional |
| 3.5 Scale guard + smoke 30min | ⏳ Operacional |
| 3.6 Scale worker + smoke 30min | ⏳ Operacional |
| 3.7 Scale self-healing + smoke 30min | ⏳ Operacional |
| 3.8 E2E 5 intents → execution.results | ⏳ Operacional |

## Risks documentados (não bloqueantes)

1. **PDB `minAvailable:1` em workloads 0/N** (CR-001) — bloqueia evictions; não agendar node drains durante TR-2.
2. **Outros charts `neural-hive` ainda não-compliant** (CR-003) — `approval-service`, `consensus-engine` usam só `app.kubernetes.io/*`. Não re-deploy durante TR-2. Ticket separado para alinhar.
3. **`schemaRegistryUrl: ""` em worker-agents** (CR-009) — TODO no chart força JSON fallback. Se pipeline upstream migrou para Avro, worker-agents crash-loop. Runbook tem step de verificação antes do scale.
4. **Drift `podLabels.version` ↔ `image.tag`** (CR-002) — manual hoje; pre-flight detecta. Follow-up: derivar no template comum.
5. **`test_full_pipeline` não existe** (GAP-1) — critério de aceitação em tasks.md refere `tests/e2e/test_intent_to_execution_flow.py::test_full_pipeline` que não existe. Substituir por teste E2E existente ou criar pós-merge.
6. **Existência remota das imagens GHCR** (GAP-2) — runbook tem step manual `docker manifest inspect`; não automatizado.
7. **ConfigMaps/Secrets no cluster** (GAP-3) — runbook tem step manual `kubectl get cm,secret`; pre-flight não verifica (é dry-run).

## Test plan (verificação pós-merge)

- [ ] CI passa nos 16 testes unitários
- [ ] Flux reconcilia os 6 charts em dev cluster sem violations Gatekeeper
- [ ] `python3 scripts/tr2_preflight_check.py` → exit 0
- [ ] Executar runbook: 6 deployments scaled, RESTARTS=0 por 30min cada
- [ ] `kubectl get hpa -n neural-hive` mostra TARGETS numérico (não `<unknown>`)
- [ ] 5 test intents via Gateway → `execution.results` recebe ≥5 messages

## Depends on

- **TR-1 (PR #102)** — Queen-Agent Redis cluster client (estável). Sem TR-1, queen-agent emite CLUSTERDOWN e os workers podem não conseguir registar-se no service-registry.

## Out of scope

- TR-3 (orchestrator-dynamic consolidation), TR-4 (Istio sidecar — PR #101)
- Alinhar outros charts `neural-hive` ao bare-label pattern (ticket separado)
- Migrar `podLabels.version` para derivação de `image.tag` no template comum (re-package todos os dependentes)
- Criar `test_full_pipeline` E2E (requer cluster real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)