### PR TITLE
feat(TR-3): orchestrator-dynamic consolidation — pre-check + runbook

### DIFF
--- a/docs/runbooks/orchestrator-dynamic-consolidation.md
+++ b/docs/runbooks/orchestrator-dynamic-consolidation.md
@@ -1,0 +1,369 @@
+# Runbook — Orchestrator Dynamic Namespace Consolidation (TR-3)
+
+> Spec: `.agent-os/specs/2026-05-22-pipeline-flow-recovery/` (TR-3)
+> Depende de: TR-1 + TR-2 estáveis (queen-agent saudável + workers
+> consumindo tickets) por pelo menos 24 h consecutivas
+
+## Contexto
+
+Existem **dois deployments** `orchestrator-dynamic` no cluster:
+
+| Namespace | Origem | Estado |
+|---|---|---|
+| `neural-hive` (ou `neural-hive-{dev,staging,prod}`) | Flux-managed (`infrastructure/fluxcd/clusters/*/services/orchestrator-dynamic.yaml`) | **Canónico** — 2/2 OK, 0 restarts (85d) |
+| `orchestrator-dynamic` | Deploy manual (`kubectl apply` / `helm install` legacy, **não em git**) | 2/3 com ~110 restarts em 24d |
+
+Ambos partilham **5 consumer groups Kafka** distintos. Cada um expõe
+uma via de split-brain durante a transição:
+
+| Consumer group | Tópico consumido | Consumer |
+|---|---|---|
+| `orchestrator-dynamic` | `plans.consensus` | `decision_consumer` |
+| `orchestrator-dynamic-flow-c` | (multi-topic Flow C) | `FlowCConsumer` |
+| `orchestrator-dynamic-approval-responses` | `cognitive-plans-approval-responses` | `ApprovalResponsesConsumer` |
+| `orchestrator-execution-results` | `execution.results` | `execution_result_consumer` |
+| `orchestrator-sla-alerts` | `sla.events` | `sla_alert_consumer` |
+
+Resultado actual: rebalances entre 4 consumers (2 ns × 2 réplicas) em
+**todos** os 5 grupos, processamento não-determinístico, risco de
+split-brain de workflows Temporal.
+
+**Decisão arquitetural:** o namespace `neural-hive*` é canónico (managed
+por Flux, sob controlo de versão). O namespace `orchestrator-dynamic`
+deve ser eliminado.
+
+---
+
+## Pré-requisitos
+
+1. **TR-1 estável há ≥24h:**
+   ```bash
+   kubectl logs -n neural-hive deploy/queen-agent --since=24h \
+     | grep CLUSTERDOWN | wc -l
+   # Esperado: 0
+   ```
+
+2. **TR-2 estável há ≥24h:**
+   ```bash
+   kubectl get pods -n neural-hive -l 'app in (worker-agents,analyst-agents,guard-agents,optimizer-agents,scout-agents,self-healing-engine)' \
+     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[0].restartCount}{"\n"}{end}'
+   # Cada pod deve ter RESTARTS=0 ou número estável (sem incrementos no último 1h)
+   ```
+
+3. **Pre-flight passa sem blockers:**
+   ```bash
+   python3 scripts/tr3_preflight_check.py
+   echo "Exit code: $?"   # 0 = OK proceder
+   ```
+
+   Atenção especial a:
+   - PVCs no ns legacy (blocker — confirmar que state é descartável)
+   - Imagens divergentes entre legacy e canónico (warning)
+   - Secrets custom (Vault tokens, API keys específicas)
+
+4. **Backup do estado Temporal:** os workflows Temporal são
+   persistidos no servidor Temporal (não nos pods do orchestrator), pelo
+   que a eliminação dos pods do orchestrator NÃO perde workflows.
+   Confirmar:
+   ```bash
+   kubectl exec -n temporal sts/temporal -- \
+     tctl --ns default workflow list -p 1 | head -20
+   ```
+   Se houver workflows `Running`, anotar IDs; vão continuar a processar
+   no orchestrator do ns canónico após Fase 1.
+
+---
+
+## Fase 1 — Scale-down reversível (24 h observação)
+
+### Step 1.1: Listar deployments no ns legacy
+
+```bash
+kubectl get deploy,svc,cm,secret,hpa,pdb,pvc -n orchestrator-dynamic
+# Anotar todos os recursos. Vão ser eliminados na Fase 2.
+```
+
+### Step 1.2a: Scale = 0 do deployment principal
+
+```bash
+kubectl scale -n orchestrator-dynamic deploy/orchestrator-dynamic --replicas=0
+# Verificar resultado:
+kubectl get deploy orchestrator-dynamic -n orchestrator-dynamic \
+  -o jsonpath='{.spec.replicas}'   # Deve devolver 0
+```
+
+### Step 1.2b: Scale = 0 do temporal-worker (explícito)
+
+A spec lista o `orchestrator-dynamic-temporal-worker` como segundo
+deployment a parar. Tratar separado para verificação clara:
+
+```bash
+if kubectl get deploy orchestrator-dynamic-temporal-worker -n orchestrator-dynamic >/dev/null 2>&1; then
+  kubectl scale -n orchestrator-dynamic \
+    deploy/orchestrator-dynamic-temporal-worker --replicas=0
+  kubectl get deploy orchestrator-dynamic-temporal-worker -n orchestrator-dynamic \
+    -o jsonpath='{.spec.replicas}'   # Deve devolver 0
+else
+  echo "INFO: temporal-worker não existe nesta instalação — skip."
+fi
+```
+
+### Step 1.2c: Aguardar expiração session_timeout
+
+```bash
+# aiokafka usa session_timeout_ms=30000 (ver flow_c_consumer.py:253).
+# Kafka só remove members após este timeout + rebalance.
+echo "Aguardando 60s para session_timeout expirar..."
+sleep 60
+```
+
+### Step 1.3: Confirmar TODOS os 5 consumer groups consolidados
+
+Snapshot dos IPs esperados (apenas pods do ns canónico):
+
+```bash
+EXPECTED_IPS=$(kubectl get pods -n neural-hive -l app=orchestrator-dynamic \
+  -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}' | sort -u)
+echo "Pods canónicos: $EXPECTED_IPS"
+```
+
+Verificar cada um dos 5 grupos:
+
+```bash
+for GROUP in orchestrator-dynamic orchestrator-dynamic-flow-c \
+             orchestrator-dynamic-approval-responses \
+             orchestrator-execution-results \
+             orchestrator-sla-alerts; do
+  echo "=== $GROUP ==="
+  kubectl exec -n kafka neural-hive-kafka-0 -- \
+    kafka-consumer-groups.sh --bootstrap-server localhost:9092 \
+    --group "$GROUP" --describe 2>/dev/null \
+    | awk 'NR>1 && $8 != "" && $8 != "HOST" {print $8}' \
+    | sort -u
+  # Critério de aceitação: TODOS os HOSTs devem estar em $EXPECTED_IPS.
+done
+```
+
+**Critério automatizável:** o pre-flight check (`scripts/tr3_preflight_check.py`)
+fornece a contagem distinta de CONSUMER-IDs por grupo. Se exceder 2 em
+qualquer grupo, há split residual.
+
+### Step 1.4: Observação 24 h
+
+Métricas a observar (Grafana / Prometheus):
+
+| Métrica | Threshold | Acção se falhar |
+|---|---|---|
+| `kafka_consumergroup_lag{group="orchestrator-dynamic"}` | < 100 sustained | Investigar; possível rollback Fase 1 |
+| Temporal `temporal_workflow_completed_total` taxa | ≥ baseline pré-Fase 1 | Idem |
+| `kube_pod_container_status_restarts_total{namespace="neural-hive",pod=~"orchestrator-dynamic.*"}` | == 0 (24 h) | Investigar pods canónicos |
+| Logs `kubectl logs deploy/orchestrator-dynamic -n neural-hive` | sem `DEADLINE_EXCEEDED`, `RACE`, `DUPLICATE_WORKFLOW` | Rollback |
+
+### Step 1.5: Rollback Fase 1 (reversível instantaneamente)
+
+Se qualquer critério falhar:
+
+```bash
+kubectl scale -n orchestrator-dynamic deploy/orchestrator-dynamic --replicas=2
+# Restaurar réplicas anteriores. Verificar consumer group volta ao split.
+```
+
+Após rollback, abrir ticket de investigação. **Não prosseguir para
+Fase 2** enquanto a causa não for entendida.
+
+---
+
+## Fase 2 — Eliminação (irreversível)
+
+Executar **apenas após 24 h de Fase 1 sem regressão**.
+
+### Step 2.1: Confirmação final
+
+```bash
+python3 scripts/tr3_preflight_check.py --json | jq '.blockers, .warnings'
+# Re-correr 24h depois para garantir que o estado não mudou.
+```
+
+### Step 2.2: Identificar tipo de instalação
+
+```bash
+helm list -n orchestrator-dynamic
+```
+
+Se houver releases Helm → usar `helm uninstall`. Se não → `kubectl delete`
+manifest a manifest.
+
+### Step 2.3: Eliminar recursos
+
+**Variante A — Helm-managed:**
+```bash
+helm uninstall orchestrator-dynamic -n orchestrator-dynamic
+```
+
+**Variante B — Manifest manual:**
+
+*Step 2.3.B.1 — Eliminar workloads e services* (reversível com
+re-deploy via Flux ou re-aplicar manifest legacy se backup existir):
+```bash
+for kind in hpa pdb deploy statefulset daemonset job cronjob; do
+  kubectl delete $kind --all -n orchestrator-dynamic --wait=true
+done
+kubectl delete svc --all -n orchestrator-dynamic
+kubectl delete cm,secret -n orchestrator-dynamic --all
+```
+
+*Step 2.3.B.2 — Cross-check secrets antes de prosseguir:*
+```bash
+# Para cada secret custom reportado pelo pre-flight em `secrets_legacy`,
+# confirmar que existe um par no ns canónico antes de descartar:
+for SECRET in $(python3 scripts/tr3_preflight_check.py --json \
+                | jq -r '.info.secrets_legacy[]?.name // empty'); do
+  kubectl get secret "$SECRET" -n neural-hive >/dev/null 2>&1 \
+    && echo "OK: $SECRET existe em neural-hive" \
+    || echo "ATENÇÃO: $SECRET NÃO existe em neural-hive — não descartar!"
+done
+```
+
+*Step 2.3.B.3 — Eliminar PVCs (IRREVERSÍVEL — confirmação interactiva):*
+```bash
+# CRITICAL: este passo destrói state local. O pre-flight bloqueia se
+# detectar PVCs sem confirmação humana de descartabilidade. Aqui
+# adicionar gate explícito:
+PVC_LIST=$(kubectl get pvc -n orchestrator-dynamic -o name)
+if [ -n "$PVC_LIST" ]; then
+  echo "PVCs a eliminar:"
+  echo "$PVC_LIST"
+  read -p "Confirmar que estes PVCs são descartáveis [yes/no]? " confirm
+  if [ "$confirm" = "yes" ]; then
+    kubectl delete pvc --all -n orchestrator-dynamic
+  else
+    echo "ABORT: re-executar o runbook após confirmar destino dos PVCs."
+    exit 1
+  fi
+fi
+# Aguardar release dos PVs:
+sleep 30
+kubectl get pv | grep orchestrator-dynamic || echo "OK: PVs libertos"
+```
+
+### Step 2.4: Eliminar namespace
+
+```bash
+kubectl delete namespace orchestrator-dynamic
+# Se ficar em Terminating > 60s, investigar finalizers:
+kubectl get namespace orchestrator-dynamic -o json \
+  | jq '.spec.finalizers, .status'
+```
+
+Se hang em `Terminating`, ver guia:
+[Kubernetes — Stuck Namespace Termination](https://kubernetes.io/docs/tasks/administer-cluster/namespaces/#deleting-a-namespace)
+
+### Step 2.5: Verificação pós-delete
+
+```bash
+# 1. Namespace removido
+kubectl get ns orchestrator-dynamic 2>&1 | grep -q NotFound && echo "OK: ns removido"
+
+# 2. PVCs em qualquer ns referenciando orchestrator-dynamic — devem ser 0
+kubectl get pvc -A | grep orchestrator-dynamic && echo "REMAINING PVCs" \
+  || echo "OK: sem PVCs órfãos"
+
+# 3. PVs libertos
+kubectl get pv | grep orchestrator-dynamic && echo "REMAINING PV" \
+  || echo "OK: PVs limpos"
+
+# 4. Expected Deliverable #4 da spec: apenas o deploy do ns canónico
+kubectl get deploy -A | grep orchestrator-dynamic
+# Esperado: linhas apenas em ns `neural-hive*`, NÃO `orchestrator-dynamic`.
+
+# 5. Consumer groups continuam a funcionar com 1 set de consumers
+for GROUP in orchestrator-dynamic orchestrator-dynamic-flow-c \
+             orchestrator-dynamic-approval-responses \
+             orchestrator-execution-results \
+             orchestrator-sla-alerts; do
+  echo "=== $GROUP ==="
+  kubectl exec -n kafka neural-hive-kafka-0 -- \
+    kafka-consumer-groups.sh --bootstrap-server localhost:9092 \
+    --group "$GROUP" --describe 2>/dev/null
+done
+
+# 6. Workflows Temporal sem duplicação — tentar CLI moderna `temporal`,
+# fallback para `tctl` (legado).
+TEMPORAL_POD=$(kubectl get pods -n temporal -l app=temporal -o name | head -1)
+if kubectl exec -n temporal "$TEMPORAL_POD" -- which temporal >/dev/null 2>&1; then
+  kubectl exec -n temporal "$TEMPORAL_POD" -- \
+    temporal workflow list --namespace default --limit 10
+elif kubectl exec -n temporal "$TEMPORAL_POD" -- which tctl >/dev/null 2>&1; then
+  kubectl exec -n temporal "$TEMPORAL_POD" -- \
+    tctl --ns default workflow list -p 1 | head -10
+else
+  echo "AVISO: nem temporal nem tctl disponíveis no pod $TEMPORAL_POD."
+fi
+```
+
+---
+
+## Critérios de aceitação (spec)
+
+- [ ] **Fase 1:** após scale-down, todas as partições dos 5 tópicos de
+      orchestrator consumidas apenas por `neural-hive/orchestrator-dynamic`
+- [ ] **Fase 1:** Temporal `workflow list` durante 24 h não mostra
+      workflows duplicados
+- [ ] **Fase 2:** `kubectl get deploy -A | grep orchestrator-dynamic`
+      mostra apenas a entrada em `neural-hive*/`
+- [ ] **Fase 2:** namespace `orchestrator-dynamic` removido sem afectar
+      fluxos
+- [ ] PVCs e finalizers limpos
+
+---
+
+## Riscos conhecidos
+
+1. **State em PVC não-replicado:** se o ns legacy tiver PVCs com state
+   crítico (cache local de workflows, audit logs), `kubectl delete pvc`
+   perde dados. Pre-flight reporta PVCs como **BLOCKER** — não avançar
+   sem confirmação humana.
+
+2. **Secrets divergentes:** Vault tokens, API keys ou TLS certs no ns
+   legacy podem não existir no ns canónico. Cross-check com `kubectl
+   get secret -n neural-hive` antes da Fase 2.
+
+3. **Consumer group offset reset:** ao eliminar o membro legacy do grupo,
+   o Kafka faz rebalance e atribui as partições ao membro canónico. Há
+   uma janela de 30-60s sem consumo durante o rebalance. Aceitável.
+
+4. **Workflows Temporal em flight:** se um workflow estava a ser
+   processado pelo pod legacy no momento do scale-down, o Temporal
+   re-atribui-o ao pod canónico no próximo poll. **Não há perda** —
+   mas a re-atribuição depende do `schedule_to_start_timeout` do task
+   queue (não configurado explicitamente neste serviço → default
+   ilimitado do Temporal). Em prática, o re-poll do worker canónico
+   acontece a cada poll cycle. Tempo de retomada varia com a carga;
+   monitorar `temporal_workflow_completed_total` no Grafana durante a
+   Fase 1 para detectar workflows estagnados.
+
+5. **Imagens divergentes (legacy vs canónico):** pre-flight reporta como
+   warning. Se o legacy tinha um build especial (hotfix manual, branch
+   privado), a consolidação fá-lo desaparecer. Documentar
+   explicitamente antes de proceder.
+
+6. **Outros consumers no ns legacy:** se houver workloads que NÃO sejam
+   `orchestrator-dynamic` no ns (ex.: jobs ad-hoc, debug pods), a
+   eliminação do namespace mata-os também. Pre-flight lista todos os
+   workloads detectados.
+
+7. **Hooks Helm pre-delete:** se o chart legacy era Helm-managed com
+   `pre-delete` hooks, `helm uninstall` corre-os primeiro. Confirmar com
+   `helm get hooks orchestrator-dynamic -n orchestrator-dynamic` antes.
+
+---
+
+## Referências
+
+- Spec: `.agent-os/specs/2026-05-22-pipeline-flow-recovery/spec.md`
+- Technical spec: `.agent-os/specs/2026-05-22-pipeline-flow-recovery/sub-specs/technical-spec.md`
+- Pre-flight script: `scripts/tr3_preflight_check.py`
+- Flux HelmRelease canónico: `infrastructure/fluxcd/clusters/{dev,staging,prod}/services/orchestrator-dynamic.yaml`
+- PR TR-1 (dependência): #102
+- PR TR-2 (dependência): #103
+- PR TR-4: #101

--- a/scripts/tr3_preflight_check.py
+++ b/scripts/tr3_preflight_check.py
@@ -1,0 +1,384 @@
+"""
+TR-3 pre-check: audita o namespace `orchestrator-dynamic` (legacy)
+antes da consolidação para `neural-hive`.
+
+Spec: `.agent-os/specs/2026-05-22-pipeline-flow-recovery/` (TR-3).
+
+Background:
+  - `neural-hive/orchestrator-dynamic` (Flux-managed) é o canónico (2/2 OK).
+  - `orchestrator-dynamic/orchestrator-dynamic` (manual deploy) tem
+    ~110 restarts/24d e partilha o mesmo consumer group Kafka → split
+    rebalances, processamento não-determinístico.
+
+Este script é **READ-ONLY**: NÃO executa scale, delete, ou helm
+uninstall. Apenas reporta o estado actual e levanta blockers que
+exigem decisão humana antes da execução do runbook.
+
+Verifica (requer `kubectl` configurado contra o cluster alvo):
+  1. Namespace `orchestrator-dynamic` existe
+  2. Recursos no ns legacy (deployments, statefulsets, PVCs, secrets
+     com state externo, finalizers pendentes)
+  3. Consumer group Kafka partilhado (best-effort via `kubectl exec`)
+  4. Comparação de imagens/tags entre ns legacy e neural-hive
+
+Output JSON ou human-readable. Exit 0 = OK proceder com runbook;
+exit 1 = blocker encontrado, intervenção humana necessária.
+
+Uso:
+    python3 scripts/tr3_preflight_check.py [--ns orchestrator-dynamic]
+            [--json] [--canonical-ns neural-hive]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+LEGACY_NS_DEFAULT = "orchestrator-dynamic"
+CANONICAL_NS_DEFAULT = "neural-hive"
+# APP_NAME é intencionalmente fixo: identifica o label do Deployment
+# (`app=orchestrator-dynamic`) e o prefixo dos consumer groups. O flag
+# `--ns` configura apenas o scope namespace das queries, não o nome
+# da aplicação. Vide auditoria CR-009.
+APP_NAME = "orchestrator-dynamic"
+
+# Consumer groups verificados durante a consolidação. Fonte:
+# `services/orchestrator-dynamic/src/config/settings.py` (5 entradas)
+# e os respectivos consumers em `src/consumers/`.
+CONSUMER_GROUPS = (
+    "orchestrator-dynamic",  # decision_consumer (plans.consensus)
+    "orchestrator-dynamic-flow-c",  # FlowCConsumer
+    "orchestrator-dynamic-approval-responses",  # cognitive-plans-approval-responses
+    "orchestrator-execution-results",  # execution.results
+    "orchestrator-sla-alerts",  # sla.events
+)
+
+
+@dataclass
+class CheckReport:
+    legacy_ns: str
+    canonical_ns: str
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return not self.blockers
+
+    def block(self, msg: str) -> None:
+        self.blockers.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+
+def _kubectl(args: list[str]) -> tuple[int, str, str]:
+    """Invoca kubectl; devolve (rc, stdout, stderr)."""
+    kubectl = shutil.which("kubectl")
+    if not kubectl:
+        raise RuntimeError("kubectl não disponível no PATH")
+    # Args são lista (sem shell), kubectl literal: zero injection surface.
+    proc = subprocess.run([kubectl, *args], capture_output=True, text=True, check=False)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def check_ns_exists(report: CheckReport) -> bool:
+    """Confirma que o namespace legacy existe. Se não existir, nada a
+    fazer — TR-3 já foi executado ou nunca houve drift.
+    """
+    rc, out, _ = _kubectl(["get", "ns", report.legacy_ns, "-o", "json"])
+    if rc != 0:
+        report.info["ns_legacy_exists"] = False
+        report.warn(
+            f"Namespace `{report.legacy_ns}` não existe — TR-3 já foi "
+            "consolidado ou drift inexistente. Nada a fazer."
+        )
+        return False
+
+    try:
+        meta = json.loads(out).get("metadata", {})
+        finalizers = meta.get("finalizers", [])
+        if finalizers:
+            report.warn(
+                f"Namespace `{report.legacy_ns}` tem finalizers: {finalizers}. "
+                "Fase 2 (delete ns) pode bloquear até estes serem libertados."
+            )
+        report.info["ns_legacy_exists"] = True
+        report.info["ns_finalizers"] = finalizers
+    except json.JSONDecodeError:
+        report.warn("Falha a parsear metadata do namespace legacy.")
+
+    return True
+
+
+def list_legacy_workloads(report: CheckReport) -> None:
+    """Lista deployments/statefulsets/daemonsets no ns legacy."""
+    for kind in ("deployment", "statefulset", "daemonset"):
+        rc, out, _ = _kubectl(["get", kind, "-n", report.legacy_ns, "-o", "json"])
+        if rc != 0:
+            continue
+        try:
+            items = json.loads(out).get("items", [])
+        except json.JSONDecodeError:
+            continue
+
+        if items:
+            workload_list = [
+                {
+                    "name": w.get("metadata", {}).get("name"),
+                    "replicas": w.get("spec", {}).get("replicas", 0),
+                    "ready": w.get("status", {}).get("readyReplicas", 0),
+                    "image": (
+                        w.get("spec", {})
+                        .get("template", {})
+                        .get("spec", {})
+                        .get("containers", [{}])[0]
+                        .get("image", "")
+                    ),
+                }
+                for w in items
+            ]
+            report.info[f"{kind}s_legacy"] = workload_list
+
+
+def check_state_resources(report: CheckReport) -> None:
+    """PVCs e StatefulSets no ns legacy implicam state local que vai
+    ser perdido com `kubectl delete ns`. Levantar como BLOCKER se
+    houver — operador deve confirmar que o state é descartável ou
+    migrar para o ns canónico antes da Fase 2.
+    """
+    rc, out, _ = _kubectl(["get", "pvc", "-n", report.legacy_ns, "-o", "json"])
+    if rc == 0:
+        try:
+            pvcs = json.loads(out).get("items", [])
+        except json.JSONDecodeError:
+            # CRITICAL: PVC check é o único BLOCKER destrutivo (state real
+            # pode ser perdido). Output malformed (kubectl version mismatch,
+            # API server stress) NÃO pode silenciar este check.
+            report.block(
+                "kubectl get pvc devolveu output não-parseável — não é "
+                "possível avaliar state em PVCs. Abortar Fase 2."
+            )
+            pvcs = []
+        if pvcs:
+            pvc_summary = [
+                {
+                    "name": p.get("metadata", {}).get("name"),
+                    "capacity": p.get("spec", {})
+                    .get("resources", {})
+                    .get("requests", {})
+                    .get("storage"),
+                    "storage_class": p.get("spec", {}).get("storageClassName"),
+                }
+                for p in pvcs
+            ]
+            report.info["pvcs_legacy"] = pvc_summary
+            report.block(
+                f"{len(pvcs)} PVC(s) no ns legacy. Confirma com o owner se "
+                "estão a guardar state crítico (Temporal workflows persistentes, "
+                "audit logs). Se sim, migrar antes de Fase 2. Se descartáveis, "
+                "documentar explicitamente."
+            )
+
+    rc, out, _ = _kubectl(["get", "secret", "-n", report.legacy_ns, "-o", "json"])
+    if rc == 0:
+        try:
+            secrets = json.loads(out).get("items", [])
+        except json.JSONDecodeError:
+            secrets = []
+        # Ignorar default service-account-token / helm-related.
+        relevant = [
+            s
+            for s in secrets
+            if s.get("type") not in ("kubernetes.io/service-account-token",)
+            and not s.get("metadata", {}).get("name", "").startswith("sh.helm.release")
+        ]
+        if relevant:
+            report.info["secrets_legacy"] = [
+                {"name": s.get("metadata", {}).get("name"), "type": s.get("type")} for s in relevant
+            ]
+            report.warn(
+                f"{len(relevant)} secret(s) custom no ns legacy. Confirma se "
+                "credenciais não-replicadas no ns canónico (Vault tokens, "
+                "API keys específicas) antes da Fase 2."
+            )
+
+
+def check_image_consistency(report: CheckReport) -> None:
+    """Compara imagens entre ns legacy e canónico. Se forem idênticas,
+    consolidação é segura. Se divergirem, levantar warning (legacy
+    pode ter behavior diferente que vai desaparecer).
+    """
+    legacy_images = set()
+    canonical_images = set()
+
+    for ns, bucket in ((report.legacy_ns, legacy_images), (report.canonical_ns, canonical_images)):
+        rc, out, _ = _kubectl(["get", "deploy", "-n", ns, "-l", f"app={APP_NAME}", "-o", "json"])
+        if rc != 0:
+            continue
+        try:
+            items = json.loads(out).get("items", [])
+        except json.JSONDecodeError:
+            continue
+        for item in items:
+            containers = (
+                item.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+            )
+            for c in containers:
+                if c.get("image"):
+                    bucket.add(c["image"])
+
+    report.info["images_legacy"] = sorted(legacy_images)
+    report.info["images_canonical"] = sorted(canonical_images)
+
+    if legacy_images and canonical_images and legacy_images != canonical_images:
+        report.warn(
+            f"Imagens divergem entre ns legacy ({sorted(legacy_images)}) e "
+            f"ns canónico ({sorted(canonical_images)}). Verificar se o legacy "
+            "tem build especial antes de descartar."
+        )
+
+
+def _count_distinct_consumer_ids(describe_output: str) -> int:
+    """Conta CONSUMER-IDs distintos (não-vazios) no output de
+    `kafka-consumer-groups.sh --describe`.
+
+    Formato esperado:
+        GROUP TOPIC PARTITION CURRENT-OFFSET LOG-END-OFFSET LAG CONSUMER-ID HOST CLIENT-ID
+
+    Contar linhas confunde members com partições (uma topic com 3
+    partições e 4 members devolve 3 linhas). Vide auditoria CR-002.
+    """
+    consumer_ids: set[str] = set()
+    for line in describe_output.splitlines():
+        cols = line.split()
+        if len(cols) < 7 or cols[0] in ("GROUP", "Group"):
+            continue
+        cid = cols[6]
+        # `-` indica partição sem owner activo (rebalance em curso).
+        if cid and cid != "-":
+            consumer_ids.add(cid)
+    return len(consumer_ids)
+
+
+def check_consumer_group_overlap(report: CheckReport, expected_members: int = 2) -> None:
+    """Verifica TODOS os 5 consumer groups conhecidos do orchestrator.
+
+    Auditoria CR-003: o ns legacy pode estar a consumir em qualquer dos
+    5 grupos derivados. Verificar só `orchestrator-dynamic` deixa 4 vias
+    de split-brain não detectadas.
+    """
+    per_group: dict[str, dict[str, object]] = {}
+
+    for group in CONSUMER_GROUPS:
+        rc, out, err = _kubectl(
+            [
+                "exec",
+                "-n",
+                "kafka",
+                "neural-hive-kafka-0",
+                "--",
+                "kafka-consumer-groups.sh",
+                "--bootstrap-server",
+                "localhost:9092",
+                "--group",
+                group,
+                "--describe",
+            ]
+        )
+        if rc != 0:
+            per_group[group] = {"status": "skipped", "reason": err.strip()[:120]}
+            continue
+
+        members = _count_distinct_consumer_ids(out)
+        per_group[group] = {"status": "ok", "distinct_consumer_ids": members}
+        if members > expected_members:
+            report.warn(
+                f"Consumer group `{group}` tem {members} members distintos "
+                f"(esperado ≤{expected_members} no ns canónico). Provável "
+                "consumo competitivo entre ns legacy e canónico."
+            )
+
+    report.info["consumer_group_check"] = per_group
+
+
+def run(legacy_ns: str, canonical_ns: str) -> CheckReport:
+    report = CheckReport(legacy_ns=legacy_ns, canonical_ns=canonical_ns)
+
+    if not check_ns_exists(report):
+        return report
+
+    list_legacy_workloads(report)
+    check_state_resources(report)
+    check_image_consistency(report)
+    check_consumer_group_overlap(report)
+
+    return report
+
+
+def _format_human(report: CheckReport) -> str:
+    lines = [f"TR-3 pre-check: legacy={report.legacy_ns} canonical={report.canonical_ns}", ""]
+    if report.blockers:
+        lines.append("BLOCKERS (decisão humana necessária):")
+        for b in report.blockers:
+            lines.append(f"  - {b}")
+        lines.append("")
+    if report.warnings:
+        lines.append("WARNINGS:")
+        for w in report.warnings:
+            lines.append(f"  - {w}")
+        lines.append("")
+    if report.info:
+        lines.append("INFO:")
+        for k, v in report.info.items():
+            lines.append(f"  {k}: {v}")
+    lines.append("")
+    lines.append("OK to proceed with runbook" if report.ok else "BLOCKED — resolve blockers first")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ns", default=LEGACY_NS_DEFAULT, help="Namespace legacy")
+    parser.add_argument(
+        "--canonical-ns",
+        default=CANONICAL_NS_DEFAULT,
+        help="Namespace canónico (Flux-managed)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        report = run(args.ns, args.canonical_ns)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": report.ok,
+                    "legacy_ns": report.legacy_ns,
+                    "canonical_ns": report.canonical_ns,
+                    "blockers": report.blockers,
+                    "warnings": report.warnings,
+                    "info": report.info,
+                },
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        print(_format_human(report))
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_tr3_preflight.py
+++ b/tests/unit/test_tr3_preflight.py
@@ -1,0 +1,381 @@
+"""
+Testes unitários para `scripts/tr3_preflight_check.py`.
+
+Foco: lógica de classificação (blocker vs warning vs info) dada output
+sintético de `kubectl`. Não invoca kubectl real — monkeypatch de
+`_kubectl()` injecta respostas.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "tr3_preflight_check.py"
+spec = importlib.util.spec_from_file_location("tr3_preflight_check", SCRIPT_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Não consigo carregar {SCRIPT_PATH}")
+tr3 = importlib.util.module_from_spec(spec)
+sys.modules["tr3_preflight_check"] = tr3
+spec.loader.exec_module(tr3)
+
+
+def _make_kubectl_stub(responses: dict[tuple[str, ...], tuple[int, str, str]]):
+    """Devolve um callable que substitui `_kubectl`. `responses` mapeia
+    prefixos de args (tuple) para (rc, stdout, stderr)."""
+
+    def _stub(args):
+        for key, value in responses.items():
+            if tuple(args[: len(key)]) == key:
+                return value
+        return (1, "", f"unknown args: {args}")
+
+    return _stub
+
+
+def test_ns_does_not_exist_returns_ok_with_warning(monkeypatch):
+    """ns inexistente → TR-3 já feito ou drift inexistente → OK + warning."""
+    responses = {("get", "ns", "orchestrator-dynamic"): (1, "", "NotFound")}
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert report.ok is True
+    assert report.info["ns_legacy_exists"] is False
+    assert any("já foi consolidado" in w for w in report.warnings)
+
+
+def test_ns_exists_no_state_no_workloads_returns_ok(monkeypatch):
+    """ns vazio (sem PVCs/secrets/deploys) → seguro proceder."""
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n", "orchestrator-dynamic"): (
+            0,
+            json.dumps({"items": []}),
+            "",
+        ),
+        ("get", "statefulset", "-n", "orchestrator-dynamic"): (
+            0,
+            json.dumps({"items": []}),
+            "",
+        ),
+        ("get", "daemonset", "-n", "orchestrator-dynamic"): (
+            0,
+            json.dumps({"items": []}),
+            "",
+        ),
+        ("get", "pvc", "-n", "orchestrator-dynamic"): (0, json.dumps({"items": []}), ""),
+        ("get", "secret", "-n", "orchestrator-dynamic"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n", "orchestrator-dynamic"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n", "neural-hive"): (0, json.dumps({"items": []}), ""),
+        ("exec", "-n", "kafka"): (1, "", "no kafka pod"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert report.ok is True
+    assert report.blockers == []
+
+
+def test_pvc_present_blocks_proceed(monkeypatch):
+    """PVC no ns legacy → BLOCKER (state pode ser crítico)."""
+    pvc_doc = {
+        "items": [
+            {
+                "metadata": {"name": "workflow-state"},
+                "spec": {
+                    "resources": {"requests": {"storage": "10Gi"}},
+                    "storageClassName": "longhorn",
+                },
+            }
+        ]
+    }
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "pvc", "-n", "orchestrator-dynamic"): (0, json.dumps(pvc_doc), ""),
+        ("get", "secret", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n"): (0, json.dumps({"items": []}), ""),
+        ("exec",): (1, "", "skip"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert report.ok is False
+    assert any("PVC" in b for b in report.blockers)
+    assert "pvcs_legacy" in report.info
+
+
+def test_finalizers_in_ns_metadata_warn(monkeypatch):
+    """Finalizers no ns → warning sobre risco de delete bloquear."""
+    ns_with_finalizers = {"metadata": {"finalizers": ["custom.io/cleanup"]}}
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps(ns_with_finalizers), ""),
+        ("get", "deployment", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "pvc", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "secret", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n"): (0, json.dumps({"items": []}), ""),
+        ("exec",): (1, "", "skip"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert any("finalizers" in w for w in report.warnings)
+    assert report.info["ns_finalizers"] == ["custom.io/cleanup"]
+
+
+def test_image_divergence_warns(monkeypatch):
+    """Imagens diferentes legacy vs canónico → warning."""
+    legacy = {
+        "items": [
+            {
+                "spec": {
+                    "template": {
+                        "spec": {"containers": [{"image": "ghcr.io/test/orch:legacy-build"}]}
+                    }
+                }
+            }
+        ]
+    }
+    canonical = {
+        "items": [
+            {"spec": {"template": {"spec": {"containers": [{"image": "ghcr.io/test/orch:1.0.0"}]}}}}
+        ]
+    }
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "pvc", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "secret", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n", "orchestrator-dynamic"): (0, json.dumps(legacy), ""),
+        ("get", "deploy", "-n", "neural-hive"): (0, json.dumps(canonical), ""),
+        ("exec",): (1, "", "skip"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert any("Imagens divergem" in w for w in report.warnings)
+
+
+def test_custom_secrets_warn_but_dont_block(monkeypatch):
+    """Secrets custom → warning, não blocker."""
+    secrets_doc = {
+        "items": [
+            {"metadata": {"name": "vault-token"}, "type": "Opaque"},
+            {
+                "metadata": {"name": "default-token-abc"},
+                "type": "kubernetes.io/service-account-token",
+            },
+        ]
+    }
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "pvc", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "secret", "-n"): (0, json.dumps(secrets_doc), ""),
+        ("get", "deploy", "-n"): (0, json.dumps({"items": []}), ""),
+        ("exec",): (1, "", "skip"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert report.ok is True  # warning, não blocker
+    assert any("secret(s) custom" in w for w in report.warnings)
+    # Default tokens ignorados na contagem
+    assert "vault-token" in str(report.info.get("secrets_legacy", []))
+    assert "default-token-abc" not in str(report.info.get("secrets_legacy", []))
+
+
+def test_json_output_serializes(monkeypatch, capsys):
+    responses = {("get", "ns", "orchestrator-dynamic"): (1, "", "NotFound")}
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    exit_code = tr3.main(["--json"])
+    captured = capsys.readouterr().out
+
+    payload = json.loads(captured)
+    assert payload["ok"] is True
+    assert payload["legacy_ns"] == "orchestrator-dynamic"
+    assert payload["canonical_ns"] == "neural-hive"
+    assert exit_code == 0
+
+
+def test_exit_code_1_when_blocker(monkeypatch, capsys):
+    pvc_doc = {
+        "items": [
+            {
+                "metadata": {"name": "x"},
+                "spec": {
+                    "resources": {"requests": {"storage": "1Gi"}},
+                    "storageClassName": "default",
+                },
+            }
+        ]
+    }
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "pvc", "-n", "orchestrator-dynamic"): (0, json.dumps(pvc_doc), ""),
+        ("get", "secret", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n"): (0, json.dumps({"items": []}), ""),
+        ("exec",): (1, "", "skip"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    exit_code = tr3.main([])
+    assert exit_code == 1
+
+
+def test_consumer_group_skipped_when_kafka_unreachable(monkeypatch):
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "pvc", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "secret", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n"): (0, json.dumps({"items": []}), ""),
+        ("exec", "-n", "kafka"): (1, "", "pod not found"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert report.ok is True
+    # Cada um dos 5 grupos deve estar marcado como "skipped"
+    cg_check = report.info.get("consumer_group_check", {})
+    assert isinstance(cg_check, dict)
+    assert len(cg_check) == len(tr3.CONSUMER_GROUPS)
+    assert all(g["status"] == "skipped" for g in cg_check.values())
+
+
+def test_consumer_group_detects_split_brain(monkeypatch):
+    """CR-002 + CR-003: detectar excess de consumer-ids num qualquer grupo."""
+    # Output sintético com 4 consumer-ids distintos (split entre 2 nss)
+    describe_out = (
+        "GROUP TOPIC PARTITION CURRENT-OFFSET LOG-END-OFFSET LAG CONSUMER-ID HOST CLIENT-ID\n"
+        "g topic 0 100 100 0 consumer-id-a host-1 c1\n"
+        "g topic 1 100 100 0 consumer-id-b host-2 c2\n"
+        "g topic 2 100 100 0 consumer-id-c host-3 c3\n"
+        "g topic 0 100 100 0 consumer-id-d host-4 c4\n"  # 4º member, partição já vista
+    )
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "pvc", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "secret", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n"): (0, json.dumps({"items": []}), ""),
+        ("exec", "-n", "kafka"): (0, describe_out, ""),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    # Threshold default expected_members=2 → 4 members > 2 → warning per group
+    assert any("consumo competitivo" in w for w in report.warnings)
+
+
+def test_consumer_id_counting_ignores_header_and_idle(monkeypatch):
+    """CR-002: header (GROUP) e partições sem owner (-) não contam."""
+    out = (
+        "GROUP TOPIC PARTITION CURRENT-OFFSET LOG-END-OFFSET LAG CONSUMER-ID HOST CLIENT-ID\n"
+        "g topic 0 100 100 0 consumer-a host-1 c1\n"
+        "g topic 1 100 100 0 - - -\n"  # partição sem owner
+        "g topic 2 100 100 0 consumer-a host-1 c1\n"  # mesmo consumer 2x
+    )
+    assert tr3._count_distinct_consumer_ids(out) == 1
+
+
+def test_pvc_malformed_json_blocks(monkeypatch):
+    """CR-001 CRITICAL: kubectl PVC output malformed deve BLOQUEAR."""
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        # PVC retorna JSON malformed (kubectl truncado, version mismatch).
+        ("get", "pvc", "-n", "orchestrator-dynamic"): (0, "{ not json", ""),
+        ("get", "secret", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n"): (0, json.dumps({"items": []}), ""),
+        ("exec",): (1, "", "skip"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert report.ok is False
+    assert any("não-parseável" in b for b in report.blockers)
+
+
+def test_kubectl_absent_returns_exit_2(monkeypatch, capsys):
+    """CR-007: kubectl não disponível → exit 2 (erro de execução)."""
+
+    def _no_kubectl(_args):
+        raise RuntimeError("kubectl não disponível no PATH")
+
+    monkeypatch.setattr(tr3, "_kubectl", _no_kubectl)
+
+    exit_code = tr3.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "kubectl não disponível" in captured.err
+
+
+def test_workload_list_populated(monkeypatch):
+    deploy_doc = {
+        "items": [
+            {
+                "metadata": {"name": "orchestrator-dynamic"},
+                "spec": {
+                    "replicas": 2,
+                    "template": {"spec": {"containers": [{"image": "ghcr.io/test/orch:legacy"}]}},
+                },
+                "status": {"readyReplicas": 1},
+            }
+        ]
+    }
+    responses = {
+        ("get", "ns", "orchestrator-dynamic"): (0, json.dumps({"metadata": {}}), ""),
+        ("get", "deployment", "-n", "orchestrator-dynamic"): (
+            0,
+            json.dumps(deploy_doc),
+            "",
+        ),
+        ("get", "statefulset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "daemonset", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "pvc", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "secret", "-n"): (0, json.dumps({"items": []}), ""),
+        ("get", "deploy", "-n"): (0, json.dumps({"items": []}), ""),
+        ("exec",): (1, "", "skip"),
+    }
+    monkeypatch.setattr(tr3, "_kubectl", _make_kubectl_stub(responses))
+
+    report = tr3.run("orchestrator-dynamic", "neural-hive")
+
+    assert "deployments_legacy" in report.info
+    workloads = report.info["deployments_legacy"]
+    assert workloads[0]["name"] == "orchestrator-dynamic"
+    assert workloads[0]["replicas"] == 2
+    assert workloads[0]["ready"] == 1
+    assert "legacy" in workloads[0]["image"]


### PR DESCRIPTION
## Summary

Ticket **TR-3** do spec [`2026-05-22-pipeline-flow-recovery`](https://github.com/albinoJimy/Neural-Hive-Mind/pull/101). Entrega o material **read-only** para consolidar `orchestrator-dynamic` (eliminar o ns legacy duplicado). A execução real (scale=0 → 24h obs → delete) acontece pós-merge, em janela de manutenção, contra cluster com TR-1 + TR-2 estáveis.

## Root cause

Dois deployments `orchestrator-dynamic` coexistem partilhando **5 consumer groups Kafka** distintos:

| Consumer group | Tópico |
|---|---|
| `orchestrator-dynamic` | `plans.consensus` |
| `orchestrator-dynamic-flow-c` | (multi-topic Flow C) |
| `orchestrator-dynamic-approval-responses` | `cognitive-plans-approval-responses` |
| `orchestrator-execution-results` | `execution.results` |
| `orchestrator-sla-alerts` | `sla.events` |

Resultado: rebalances entre 4 consumers em cada grupo, processamento não-determinístico, risco real de split-brain de workflows Temporal.

## Changes

### `scripts/tr3_preflight_check.py` (novo)

READ-ONLY pre-check via kubectl. Verifica:
- Namespace legacy existe (se não → TR-3 já feito → OK)
- Workloads (deployments / statefulsets / daemonsets)
- PVCs (**BLOCKER** — state pode ser crítico)
- Secrets custom (warning — cross-check com ns canónico)
- Finalizers de namespace (warning)
- Imagens divergentes legacy ↔ canónico (warning)
- **Os 5 consumer groups** (CR-003) — conta CONSUMER-IDs distintos (não linhas — CR-002), alerta se exceder réplicas esperadas

Output JSON ou human-readable. Exit 0 / 1 / 2.

**CR-001 (CRITICAL) remediado:** kubectl `get pvc` com JSON malformed agora levanta blocker explícito em vez de bypass silencioso.

### `tests/unit/test_tr3_preflight.py` (14 tests pass)

Cobertura completa incluindo paths críticos:
- PVC JSON malformed → BLOCKER (CR-001)
- Split-brain detectado: 4 consumer-ids num único grupo → warning (CR-002 + CR-003)
- Header e partições idle (`-`) NÃO contam (CR-002)
- Kafka unreachable → todos os 5 grupos skipped
- kubectl ausente → exit 2 (CR-007)

### `docs/runbooks/orchestrator-dynamic-consolidation.md` (novo)

Procedimento 2-fase com pré-requisitos, fase reversível (scale=0 + 24h obs), fase irreversível (delete), verificação pós-delete, 7 riscos.

**Remediações de auditoria incorporadas:**
- Tabela com 5 consumer groups + tópicos (G1, CR-006)
- Step 1.2b explícito para `orchestrator-dynamic-temporal-worker` (G3)
- Step 1.2c wait 60s para session_timeout antes do consumer-group check (CR-004)
- Step 1.3 verifica os 5 grupos com snapshot de pod IPs canónicos vs HOSTs reportados (G2)
- Step 2.3.B.2 cross-check secrets explícito (G5)
- **Step 2.3.B.3 PVC delete com confirmação interactiva** (`read -p yes/no`) — único safety net antes de delete irreversível (CR-005)
- Step 2.5 verificação pós-delete completa: PVCs órfãos em todos os ns (G4), Expected Deliverable #4 (G7), fallback `temporal` CLI moderna vs `tctl` (G6)
- Risco #4 corrigido (removido claim infundado `<10s` — CR-008)

## Audit pipeline

| Auditor | Verdict | Findings | Remediados | Documentados |
|---|---|---|---|---|
| Quality (code-reviewer) | NEEDS_FIXES → SHIP | 1 CRIT + 5 WARN + 3 INFO | CR-001/002/003/004/005/006/007/008/009 | — |
| Completeness (gap-analyzer) | PARCIAL → COMPLETO | 7 gaps (2 ALTA, 3 MED, 2 BAIXA) | G1/G2/G3/G4/G5/G6/G7 | — |

Convergência alta entre auditorias: CR-002+G2, CR-003+G1, CR-004+G3, CR-006+G1 — todos remediados.

## Subtasks status (TR-3 em tasks.md)

| Subtask | Status |
|---|---|
| 4.1 Scale-down (fase 1) | ⏳ Documented runbook step (operacional) |
| 4.2 Monitor 24h | ⏳ Métricas documentadas + critérios rollback |
| 4.3 Consumer group consolidado | ✅ Pre-flight + runbook verificam os 5 grupos |
| 4.4 Fase 2 — remoção | ⏳ Runbook variants A (helm) + B (kubectl) |
| 4.5 Eliminar namespace | ⏳ Step 2.4 |
| 4.6 PVCs + finalizers limpos | ✅ Verificação automatizada pós-delete |

## Risks documentados

1. **State em PVC não-replicado** — pre-flight BLOCKER + confirmação interactiva no runbook
2. **Secrets divergentes** — cross-check explícito Step 2.3.B.2
3. **Consumer group rebalance** — janela 30-60s de não-consumo (aceitável)
4. **Workflows Temporal em flight** — re-atribuição automática ao canónico; sem perda
5. **Imagens divergentes** — pre-flight warning
6. **Outros workloads no ns legacy** — pre-flight lista todos
7. **Helm pre-delete hooks** — operador deve confirmar com `helm get hooks` antes

## Test plan (verificação pós-merge)

- [ ] CI passa nos 14 testes unitários
- [ ] `python3 scripts/tr3_preflight_check.py` corre contra dev cluster sem erros
- [ ] Verificar TR-1 + TR-2 estáveis há ≥24h
- [ ] Executar Fase 1 do runbook em janela de manutenção
- [ ] 24h de observação sem regressões
- [ ] Executar Fase 2 (irreversível) com confirmações humanas
- [ ] Expected Deliverable #4: `kubectl get deploy -A | grep orchestrator-dynamic` mostra apenas ns `neural-hive*`

## Depends on

- **TR-1 (PR #102)** — Queen-Agent Redis cluster (estável)
- **TR-2 (PR #103)** — Worker fleet reactivation (estável)

Ambos devem estar estáveis há ≥24h antes da execução do runbook.

## Out of scope

- TR-4 (PR #101) — independente
- Migração de state (Vault tokens, custom secrets) entre namespaces — manual no runbook
- Validação Temporal via cluster real — necessita janela de manutenção

🤖 Generated with [Claude Code](https://claude.com/claude-code)