### PR TITLE
fix(memory-layer): add 'app' label to satisfy Gatekeeper must-have-app-label

### DIFF
--- a/helm-charts/memory-layer-api/templates/sync-consumer-deployment.yaml
+++ b/helm-charts/memory-layer-api/templates/sync-consumer-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ $fullname }}-sync-consumer
   namespace: {{ .Release.Namespace }}
   labels:
+    app: {{ $fullname }}-sync-consumer
     app.kubernetes.io/name: {{ $fullname }}-sync-consumer
     app.kubernetes.io/component: sync-consumer
     app.kubernetes.io/part-of: memory-layer-api
@@ -19,6 +20,7 @@ spec:
   template:
     metadata:
       labels:
+        app: {{ $fullname }}-sync-consumer
         app.kubernetes.io/name: {{ $fullname }}-sync-consumer
         app.kubernetes.io/component: sync-consumer
         neural-hive.io/component: memory-sync-consumer


### PR DESCRIPTION
## Summary
- ReplicaSet creation para `memory-layer-api-sync-consumer` estava bloqueada pelo Gatekeeper há 24h (103+ FailedCreate events)
- A constraint `must-have-app-label` exige `app` e `app.kubernetes.io/name`; o chart só definia o segundo
- Acumularam-se 12 ReplicaSets vazios de tentativas falhadas
- Acrescenta `app` label em `metadata.labels` e `spec.template.metadata.labels`; selector inalterado (imutável)

## Test plan
- [ ] Helm template renderiza com label `app` presente
- [ ] Após deploy, nova ReplicaSet cria com sucesso (sem FailedCreate)
- [ ] Pods sync-consumer permanecem 2/2 Ready
- [ ] Limpeza dos 11 RSes vazios pós-rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)