### PR TITLE
fix(scheduling): topologySpread to istiod + pii-service (vmi3313361 degradation)

### DIFF
--- a/helm-charts/istio-base/values-istiod-override.yaml
+++ b/helm-charts/istio-base/values-istiod-override.yaml
@@ -35,3 +35,20 @@ pilot:
     requests:
       cpu: 100m
       memory: 1Gi
+
+  # Topology spread (adicionado 2026-05-23):
+  # HPA escalou istiod para 5 réplicas; 4/5 caíram no vmi3313361 (novo node)
+  # que sofre packet loss intermitente do backbone Contabo. Resultado:
+  # readiness probes a falhar via :8080 com "context deadline exceeded",
+  # sidecar-injection webhook timeout, e ReplicaSet rollouts bloqueados.
+  #
+  # Forçar distribuição entre nodes: maxSkew=1 garante diferença máxima
+  # de 1 pod entre nodes; whenUnsatisfiable=ScheduleAnyway evita pods
+  # Pending se o scheduler não conseguir respeitar (em manutenção).
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app: istiod

--- a/helm-charts/memory-layer-api/templates/sync-consumer-deployment.yaml
+++ b/helm-charts/memory-layer-api/templates/sync-consumer-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ $fullname }}-sync-consumer
   namespace: {{ .Release.Namespace }}
   labels:
+    app: {{ $fullname }}-sync-consumer
     app.kubernetes.io/name: {{ $fullname }}-sync-consumer
     app.kubernetes.io/component: sync-consumer
     app.kubernetes.io/part-of: memory-layer-api
@@ -19,6 +20,7 @@ spec:
   template:
     metadata:
       labels:
+        app: {{ $fullname }}-sync-consumer
         app.kubernetes.io/name: {{ $fullname }}-sync-consumer
         app.kubernetes.io/component: sync-consumer
         neural-hive.io/component: memory-sync-consumer

--- a/helm-charts/pii-service/templates/deployment.yaml
+++ b/helm-charts/pii-service/templates/deployment.yaml
@@ -77,3 +77,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-charts/pii-service/values.yaml
+++ b/helm-charts/pii-service/values.yaml
@@ -91,6 +91,17 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# Distribuir réplicas entre nodes (evita concentrar 2/6 num único host).
+# Default ScheduleAnyway para não bloquear deploy se cluster tiver
+# restrições temporárias (cordon/manutenção).
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: pii-service
+
 # Configurações da aplicação (env vars não-sensíveis -> ConfigMap)
 config:
   # Aplicação


### PR DESCRIPTION
Contexto: vmi3313361 sofre packet loss Contabo. Concentrou 4/5 istiod e 2/6 pii-service. Esta mudanca adiciona topologySpreadConstraints (maxSkew=1, hostname, ScheduleAnyway) ao istiod (values override - aplicar via helm upgrade manual) e pii-service (chart proprio). Resolve readiness probe timeouts e sidecar webhook failures.