### PR TITLE
fix(deploy): blockers de arranque — asyncpg + neural_hive_security

### DIFF
--- a/services/approval-service/Dockerfile
+++ b/services/approval-service/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY libraries/python/neural_hive_domain /tmp/neural_hive_domain
 COPY libraries/python/neural_hive_specialists /tmp/neural_hive_specialists
 COPY libraries/python/neural_hive_observability /tmp/neural_hive_observability
+COPY libraries/python/neural_hive_security /tmp/neural_hive_security
 
 # Copy requirements (base + service) and install dependencies
 COPY requirements-base.txt ./requirements-base.txt
@@ -24,6 +25,7 @@ RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirement
     pip install --no-cache-dir --user /tmp/neural_hive_domain && \
     pip install --no-cache-dir --user /tmp/neural_hive_specialists && \
     pip install --no-cache-dir --user /tmp/neural_hive_observability && \
+    pip install --no-cache-dir --user /tmp/neural_hive_security && \
     pip install --no-cache-dir --user -r requirements.txt && \
     python -m uvicorn --version && \
     echo "✓ uvicorn runtime verification passed"

--- a/services/execution-ticket-service/requirements.txt
+++ b/services/execution-ticket-service/requirements.txt
@@ -4,3 +4,5 @@
 # Service-specific dependencies
 PyJWT==2.8.0
 deap==1.4.1
+# Driver PostgreSQL async usado em src/database/postgres_client.py (postgresql+asyncpg://)
+asyncpg==0.29.0


### PR DESCRIPTION
## Sumário

Corrige 2 blockers de arranque descobertos numa validação profunda do cluster (pods em CrashLoop por dependências em falta nas imagens).

## Alterações

- **execution-ticket-service**: adiciona `asyncpg==0.29.0` ao requirements. O `postgres_client.py` usa `postgresql+asyncpg://` mas o driver não estava declarado → `ModuleNotFoundError: No module named 'asyncpg'` (~1080 restarts).
- **approval-service**: o Dockerfile passa a copiar/instalar `neural_hive_security`. O `settings.py` importa `from neural_hive_security.cors import CORSConfig` mas a lib não era instalada → `ModuleNotFoundError` no rollout.

## Contexto

3º blocker relacionado (orchestrator-dynamic, bug `neural_hive_observability/middleware.py`) **já está corrigido em main** (commit 3ebaec41) — precisa apenas de rebuild da imagem, sem alteração de código.

## Testing

- Confirmado que `asyncpg==0.29.0` é a versão já usada noutros serviços do monorepo.
- Confirmado que `neural_hive_security` tem `pyproject.toml` + módulo `cors.py` (instalável).

🤖 Generated with [Claude Code](https://claude.com/claude-code)