### PR TITLE
fix(approval-service): instalar neural_hive_approval_common na imagem

### DIFF
--- a/services/approval-service/Dockerfile
+++ b/services/approval-service/Dockerfile
@@ -17,6 +17,7 @@ COPY libraries/python/neural_hive_domain /tmp/neural_hive_domain
 COPY libraries/python/neural_hive_specialists /tmp/neural_hive_specialists
 COPY libraries/python/neural_hive_observability /tmp/neural_hive_observability
 COPY libraries/python/neural_hive_security /tmp/neural_hive_security
+COPY libraries/python/neural_hive_approval_common /tmp/neural_hive_approval_common
 
 # Copy requirements (base + service) and install dependencies
 COPY requirements-base.txt ./requirements-base.txt
@@ -26,6 +27,7 @@ RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirement
     pip install --no-cache-dir --user /tmp/neural_hive_specialists && \
     pip install --no-cache-dir --user /tmp/neural_hive_observability && \
     pip install --no-cache-dir --user /tmp/neural_hive_security && \
+    pip install --no-cache-dir --user /tmp/neural_hive_approval_common && \
     pip install --no-cache-dir --user -r requirements.txt && \
     python -m uvicorn --version && \
     echo "✓ uvicorn runtime verification passed"


### PR DESCRIPTION
## Sumário

Follow-up do PR #107. Após corrigir `neural_hive_security`, o rollout do approval-service revelou outra lib interna em falta na imagem: `neural_hive_approval_common` (importada no código mas não instalada no Dockerfile) → `ModuleNotFoundError`.

## Alteração

Adiciona `COPY` + `pip install` de `neural_hive_approval_common` no Dockerfile do approval-service. Confirmado que a lib não tem dependências internas em cascata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)