### PR TITLE
fix(orchestrator): remover neural_hive_observability stale da base image

### DIFF
--- a/services/orchestrator-dynamic/Dockerfile
+++ b/services/orchestrator-dynamic/Dockerfile
@@ -62,6 +62,22 @@ RUN mkdir -p /app/logs /app/tmp && chown -R orchestrator:orchestrator /app
 # Copiar dependências instaladas do builder
 COPY --from=builder --chown=orchestrator:orchestrator /root/.local /home/orchestrator/.local
 
+# Force-reinstall neural_hive_observability para sobrepor a cópia antiga da base image.
+# A base python-observability-base:1.2.6 traz uma versão antiga desta lib (sem o
+# tratamento de AttributeError no TraceContextMiddleware), que faz cada request crashar
+# com "'property' object has no attribute 'trace_context_extraction_total'".
+# `pip install --force-reinstall` é um no-op SILENCIOSO quando o dir target já existe;
+# é preciso remover a árvore stale primeiro e só depois reinstalar com --user.
+COPY --chown=orchestrator:orchestrator libraries/python/neural_hive_observability /tmp/neural_hive_observability
+USER orchestrator
+RUN rm -rf /home/orchestrator/.local/lib/python3.11/site-packages/neural_hive_observability \
+           /home/orchestrator/.local/lib/python3.11/site-packages/neural_hive_observability-*.dist-info \
+           /home/orchestrator/.local/lib/python3.11/site-packages/neural_hive_observability-*.egg-info && \
+    pip install --no-cache-dir --no-deps --user /tmp/neural_hive_observability && \
+    python -c "import neural_hive_observability.middleware as m; import inspect; assert 'AttributeError' in inspect.getsource(m), 'fix do middleware ausente na lib instalada'; print('Middleware fix verified')"
+USER root
+RUN rm -rf /tmp/neural_hive_observability
+
 # Definir PATH e PYTHONPATH para incluir user packages e base image packages
 ENV PATH=/home/orchestrator/.local/bin:$PATH
 ENV PYTHONPATH=/home/orchestrator/.local/lib/python3.11/site-packages:/usr/local/lib/python3.11/site-packages:/app


### PR DESCRIPTION
## Sumário

3º blocker da validação de cluster. O orchestrator-dynamic crashava a cada request com `AttributeError: 'property' object has no attribute 'trace_context_extraction_total'` em `neural_hive_observability/middleware.py:163` (1300+ restarts).

## Causa-raiz

O fix do middleware (`3ebaec41`, 2026-04-29 20:53) está em main, mas a base image `python-observability-base:1.2.6` foi construída a partir de código anterior (`272ba8c1`, 2026-04-29 11:34) e **embute a versão antiga (buggy)** da lib. O `--force-reinstall` no builder é um no-op silencioso quando o dir já existe.

## Solução

Mesmo padrão já validado no STE (commit `abaa59f3`): na stage runtime, `rm -rf` da árvore stale em `.local` + reinstall `--no-deps --user` + verificação `assert 'AttributeError' in inspect.getsource(middleware)` que **falha o build** se a versão errada for instalada.

## Nota

14 serviços partilham esta base — os que usam `TraceContextMiddleware` têm o mesmo bug latente. Fix definitivo seria rebuildar a base image com bump de versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)