### PR TITLE
fix(observability): migrar 9 serviços para python-observability-base:1.3.0 (fix definitivo)

### DIFF
--- a/services/analyst-agents/Dockerfile
+++ b/services/analyst-agents/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Builder
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6 AS builder
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0 AS builder
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --user /tmp/neural_hive_resilience && \
 
 # Stage 2: Runtime - use same base to get neural_hive_observability
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0
 
 WORKDIR /app
 

--- a/services/execution-ticket-service/Dockerfile
+++ b/services/execution-ticket-service/Dockerfile
@@ -1,6 +1,6 @@
 # Single stage build using observability base
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0
 
 WORKDIR /app
 

--- a/services/explainability-api/Dockerfile
+++ b/services/explainability-api/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Builder
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6 AS builder
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0 AS builder
 
 WORKDIR /build
 
@@ -21,7 +21,7 @@ RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirement
 
 # Stage 2: Runtime (herda da base de observabilidade com todos os pacotes)
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0
 
 WORKDIR /app
 

--- a/services/orchestrator-dynamic/Dockerfile
+++ b/services/orchestrator-dynamic/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Builder
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6 AS builder
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0 AS builder
 
 # Instalar dependências de build
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Stage 2: Runtime - usar mesma base para manter neural_hive_observability
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0
 
 # Metadados OCI para rastreabilidade
 LABEL org.opencontainers.image.title="Orchestrator Dynamic"
@@ -62,14 +62,13 @@ RUN mkdir -p /app/logs /app/tmp && chown -R orchestrator:orchestrator /app
 # Copiar dependências instaladas do builder
 COPY --from=builder --chown=orchestrator:orchestrator /root/.local /home/orchestrator/.local
 
-# Substituir a versão STALE de neural_hive_observability na base image (/usr/local).
+# Defense-in-depth: garante a versão corrigida de neural_hive_observability em /usr/local.
+# A base 1.3.0 já inclui o fix do TraceContextMiddleware, mas este passo protege contra
+# regressões da base e mantém a invariante explícita no serviço.
 # CRÍTICO: o PYTHONPATH de runtime é definido pelo deployment como
 # "/app/libs:/usr/local/lib/python3.11/site-packages" (NÃO inclui ~/.local), por isso a
 # app importa o middleware de /usr/local — é AÍ que a correção tem de estar.
-# A base python-observability-base:1.2.6 (anterior ao fix 3ebaec41) traz a versão antiga
-# do TraceContextMiddleware, que crasha cada request com "'property' object has no
-# attribute 'trace_context_extraction_total'". `pip --force-reinstall` é no-op silencioso
-# se o dir já existe; é preciso remover a árvore stale antes de reinstalar.
+# `pip --force-reinstall` é no-op silencioso se o dir já existe; remover a árvore antes.
 COPY libraries/python/neural_hive_observability /tmp/neural_hive_observability
 RUN rm -rf /usr/local/lib/python3.11/site-packages/neural_hive_observability \
            /usr/local/lib/python3.11/site-packages/neural_hive_observability-*.dist-info \

--- a/services/scout-agents/Dockerfile
+++ b/services/scout-agents/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for Scout Agents
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6 AS builder
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0 AS builder
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirement
 
 # Runtime stage
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0
 
 WORKDIR /app
 

--- a/services/self-healing-engine/Dockerfile
+++ b/services/self-healing-engine/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1 - Builder
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6 AS builder
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
@@ -29,7 +29,7 @@ COPY services/self-healing-engine/src/ ./src/
 
 # Stage 2 - Runtime
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/semantic-translation-engine/Dockerfile
+++ b/services/semantic-translation-engine/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for Semantic Translation Engine
 # Stage 1: Builder
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6 AS builder
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0 AS builder
 
 WORKDIR /build
 
@@ -35,7 +35,7 @@ RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirement
 
 # Stage 2: Runtime
 # IMPORTANTE: deve ficar alinhado com a versão Python da imagem builder
-# (python-observability-base:1.2.6 -> Python 3.11). Caso contrário, os módulos
+# (python-observability-base:1.3.0 -> Python 3.11). Caso contrário, os módulos
 # C compilados (ex: confluent_kafka.cimpl) ficam incompatíveis com o runtime.
 FROM python:3.11-slim
 
@@ -59,7 +59,7 @@ COPY --from=builder --chown=app:app /usr/local/lib/python3.11/site-packages /hom
 COPY --chown=app:app libraries/python/neural_hive_risk_scoring /app/libraries/neural_hive_risk_scoring
 
 # Force-reinstall neural_hive_observability to override the older copy from the base image.
-# The base image python-observability-base:1.2.6 ships an older 2.1.1 of this library
+# The base image python-observability-base:1.3.0 ships an older 2.1.1 of this library
 # (missing AttributeError handling in TraceContextMiddleware), which makes every /health
 # probe crash with 500 and traps the pod in CrashLoopBackOff.
 #

--- a/services/sla-management-system/Dockerfile
+++ b/services/sla-management-system/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Builder
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6 AS builder
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0 AS builder
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirement
 
 # Stage 2: Runtime - use same base to keep neural_hive_observability
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0
 
 WORKDIR /app
 

--- a/services/worker-agents/Dockerfile
+++ b/services/worker-agents/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1 - Builder
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6 AS builder
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
@@ -26,7 +26,7 @@ RUN sed 's|-r ../../requirements-base.txt|-r requirements-base.txt|' requirement
 
 # Stage 2 - Runtime
 ARG REGISTRY=ghcr.io/albinojimy
-FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.2.6
+FROM ${REGISTRY}/neural-hive-mind/python-observability-base:1.3.0
 
 # Create non-root user
 RUN groupadd -r worker-agent && useradd -r -g worker-agent worker-agent


### PR DESCRIPTION
## Sumário

Fix **definitivo** do bug stale do `TraceContextMiddleware` que afetou orchestrator (#109/#110) e STE (`abaa59f3`). A base `python-observability-base:1.2.6` foi construída antes do fix `3ebaec41` e embute a versão buggy da lib — bug **latente** em todos os 9 serviços que a usam.

## Solução

1. Rebuild da base → **`python-observability-base:1.3.0`** (instala o observability atual de main, com o fix). **Validada**: `m.__file__=/usr/local/...`, `TEM_FIX: True`.
2. Migração dos **9 serviços** de `:1.2.6` → `:1.3.0`: analyst-agents, execution-ticket-service, explainability-api, orchestrator-dynamic, scout-agents, self-healing-engine, semantic-translation-engine, sla-management-system, worker-agents.

## Workarounds

Os `rm-rf`+reinstall de STE/orchestrator **mantêm-se** como defense-in-depth (idempotentes com a base 1.3.0). Remoção fica como follow-up — o STE usa `PYTHONPATH=.local` e **depende** da cópia `/usr/local→.local`, por isso requer análise per-serviço.

🤖 Generated with [Claude Code](https://claude.com/claude-code)