### PR TITLE
fix(orchestrator): consolidação de endpoints — expor gRPC 50053 + alinhar clientes (Tasks 2-3)

### DIFF
--- a/helm-charts/optimizer-agents/values-local.yaml
+++ b/helm-charts/optimizer-agents/values-local.yaml
@@ -72,8 +72,8 @@ config:
       host: consensus-engine.neural-hive.svc.cluster.local
       port: 50051
     orchestrator:
-      host: orchestrator-dynamic.neural-hive.svc.cluster.local
-      port: 50051
+      host: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+      port: 50053
     analystAgents:
       host: analyst-agents.neural-hive.svc.cluster.local
       port: 50051

--- a/helm-charts/optimizer-agents/values.yaml
+++ b/helm-charts/optimizer-agents/values.yaml
@@ -95,8 +95,8 @@ config:
       host: consensus-engine.neural-hive.svc.cluster.local
       port: 50051
     orchestrator:
-      host: orchestrator-dynamic.neural-hive.svc.cluster.local
-      port: 50051
+      host: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+      port: 50053
     analystAgents:
       host: analyst-agents.neural-hive.svc.cluster.local
       port: 50051

--- a/helm-charts/orchestrator-dynamic/templates/configmap.yaml
+++ b/helm-charts/orchestrator-dynamic/templates/configmap.yaml
@@ -83,6 +83,10 @@ data:
   ML_DRIFT_BASELINE_ENABLED: {{ .Values.config.ml.driftBaselineEnabled | quote }}
   ML_BACKFILL_ERRORS: {{ .Values.config.ml.backfillErrors | quote }}
 
+  # gRPC Server (OrchestratorStrategic - contrato canónico porta 50053)
+  ENABLE_GRPC_SERVER: {{ .Values.config.grpc.enabled | default true | quote }}
+  GRPC_SERVER_PORT: {{ .Values.config.grpc.port | default 50053 | quote }}
+
   # SLA
   SLA_DEFAULT_TIMEOUT_MS: {{ printf "%d" (int64 .Values.config.sla.defaultTimeoutMs) | quote }}
   SLA_CHECK_INTERVAL_SECONDS: {{ .Values.config.sla.checkIntervalSeconds | quote }}

--- a/helm-charts/orchestrator-dynamic/values-k8s.yaml
+++ b/helm-charts/orchestrator-dynamic/values-k8s.yaml
@@ -14,8 +14,24 @@ fullnameOverride: ""
 
 service:
   type: ClusterIP
+  # NOTA: o template comum (neural-hive.service/deployment) usa service.ports.
+  # As chaves planas port/targetPort sao legadas/ignoradas; mantidas por compat.
   port: 80
   targetPort: 8000
+  ports:
+    http:
+      port: 8000
+      targetPort: 8000
+      protocol: TCP
+    # gRPC OrchestratorStrategic - contrato canonico (host:50053, INSECURE)
+    grpc:
+      port: 50053
+      targetPort: 50053
+      protocol: TCP
+    metrics:
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
 
 ingress:
   enabled: false

--- a/helm-charts/queen-agent/values-local.yaml
+++ b/helm-charts/queen-agent/values-local.yaml
@@ -37,8 +37,8 @@ config:
     prometheusPort: 9090
 
   orchestrator:
-    grpcHost: orchestrator-dynamic.neural-hive.svc.cluster.local
-    grpcPort: 50051
+    grpcHost: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+    grpcPort: 50053
 
   serviceRegistry:
     grpcHost: service-registry.neural-hive.svc.cluster.local

--- a/helm-charts/queen-agent/values.yaml
+++ b/helm-charts/queen-agent/values.yaml
@@ -103,7 +103,7 @@ config:
     queryTimeoutSeconds: 30
 
   orchestrator:
-    grpcHost: orchestrator-dynamic.neural-hive.svc.cluster.local
+    grpcHost: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
     grpcPort: 50053
     grpcTimeout: 10
 

--- a/helm-charts/self-healing-engine/values.yaml
+++ b/helm-charts/self-healing-engine/values.yaml
@@ -82,9 +82,9 @@ config:
 
   # Integration: Orchestrator Dynamic (gRPC)
   orchestrator:
-    grpcHost: orchestrator-dynamic.neural-hive-orchestration.svc.cluster.local
-    grpcPort: 50052
-    useTls: true
+    grpcHost: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+    grpcPort: 50053
+    useTls: false
     timeout: 10
 
   # Integration: OPA Policy Engine
@@ -257,9 +257,9 @@ networkPolicy:
     - port: 8000
   # Orchestrator Dynamic (gRPC)
   - namespaceSelector:
-      matchLabels: neural-hive-orchestration
+      matchLabels: orchestrator-dynamic
     ports:
-    - port: 50052
+    - port: 50053
   # OPA Policy Engine (HTTP)
   - namespaceSelector:
       matchLabels: neural-hive-governance


### PR DESCRIPTION
## Sumário

Tasks 2-3 da spec `2026-06-01-orchestrator-namespace-consolidation`. Produzido via pipeline de agentes (dev → auditoria qualidade → auditoria completude → remediação), validado com `helm lint`/`template`.

## Contexto (ADR)

O orchestrator canónico (namespace `orchestrator-dynamic`) corre o servidor gRPC `OrchestratorStrategic` na porta **50053**, mas o Service não a expunha — e os 3 clientes apontavam para hosts/portas errados (incl. portas de outros serviços: 50051=service-registry, 50052=execution-ticket; e um namespace inexistente `neural-hive-orchestration`).

## Alterações

**Task 2 — expor gRPC no canónico:**
- `orchestrator-dynamic`: `service.ports.grpc:50053` na variante de deploy (`values-k8s.yaml`) + `ENABLE_GRPC_SERVER`/`GRPC_SERVER_PORT` no ConfigMap.

**Task 3 — alinhar clientes** (todos → `orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local:50053`, insecure):
- `queen-agent`: host legacy → canónico
- `optimizer-agents`: porta 50051 → 50053; host → canónico
- `self-healing-engine`: namespace morto → canónico; porta 50052 → 50053; `useTls true→false`; NetworkPolicy idem

## Validação
- `helm lint`: 4/4 charts OK
- `helm template`: render confirma host canónico, porta 50053, USE_TLS=false
- Auditorias do pipeline: QA **PASS**, Completude **True**

## Fora deste PR (operações de cluster, pós-merge)
- Task 4: desativar os deployments legacy (`neural-hive`/`neural-hive-orchestration`) após confirmar zero tráfego
- Task 5: validação E2E no cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)