### PR TITLE
fix(agents): clientes do orchestrator → neural-hive (canónico CI/CD) — correção de rota do #112

### DIFF
--- a/helm-charts/optimizer-agents/values-local.yaml
+++ b/helm-charts/optimizer-agents/values-local.yaml
@@ -72,7 +72,7 @@ config:
       host: consensus-engine.neural-hive.svc.cluster.local
       port: 50051
     orchestrator:
-      host: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+      host: orchestrator-dynamic.neural-hive.svc.cluster.local
       port: 50053
     analystAgents:
       host: analyst-agents.neural-hive.svc.cluster.local

--- a/helm-charts/optimizer-agents/values.yaml
+++ b/helm-charts/optimizer-agents/values.yaml
@@ -95,7 +95,7 @@ config:
       host: consensus-engine.neural-hive.svc.cluster.local
       port: 50051
     orchestrator:
-      host: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+      host: orchestrator-dynamic.neural-hive.svc.cluster.local
       port: 50053
     analystAgents:
       host: analyst-agents.neural-hive.svc.cluster.local

--- a/helm-charts/queen-agent/values-local.yaml
+++ b/helm-charts/queen-agent/values-local.yaml
@@ -37,7 +37,7 @@ config:
     prometheusPort: 9090
 
   orchestrator:
-    grpcHost: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+    grpcHost: orchestrator-dynamic.neural-hive.svc.cluster.local
     grpcPort: 50053
 
   serviceRegistry:

--- a/helm-charts/queen-agent/values.yaml
+++ b/helm-charts/queen-agent/values.yaml
@@ -103,7 +103,7 @@ config:
     queryTimeoutSeconds: 30
 
   orchestrator:
-    grpcHost: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+    grpcHost: orchestrator-dynamic.neural-hive.svc.cluster.local
     grpcPort: 50053
     grpcTimeout: 10
 

--- a/helm-charts/self-healing-engine/values.yaml
+++ b/helm-charts/self-healing-engine/values.yaml
@@ -82,7 +82,7 @@ config:
 
   # Integration: Orchestrator Dynamic (gRPC)
   orchestrator:
-    grpcHost: orchestrator-dynamic.orchestrator-dynamic.svc.cluster.local
+    grpcHost: orchestrator-dynamic.neural-hive.svc.cluster.local
     grpcPort: 50053
     useTls: false
     timeout: 10


### PR DESCRIPTION
## Sumário

Correção de rota do PR #112. A investigação de deploy (Task 4) revelou que a premissa do ADR estava invertida face ao CI/CD:

- O pipeline `deploy-after-build` deploya **sempre para `neural-hive`** (namespace fixo "temporário"); o release Helm `orchestrator-dynamic` vive em `neural-hive`.
- O deployment saudável em `orchestrator-dynamic/` (3/3) era um **`kubectl apply` manual órfão**, fora do CI/CD.
- **Decisão (aprovada): `neural-hive` é o canónico** (alinhar com o pipeline).

## Alteração

Reverte o **host** dos 3 clientes de `orchestrator-dynamic.orchestrator-dynamic` → `orchestrator-dynamic.neural-hive`, **mantendo** as correções válidas do #112 (porta 50053 — eram 50051/50052 de outros serviços; `useTls=false`).

## Validação
- `helm template`: os 3 clientes renderizam host `neural-hive`, porta `50053`, USE_TLS `false`
- `helm lint`: 3/3 OK

## Pendente (operações de cluster, controladas)
- Reparar o release `neural-hive/orchestrator-dynamic` (failed) — `helm upgrade` com o chart atual (já tem `spiffe.enabled=false`, remove o volume SPIRE que prende os pods)
- Remover o deploy manual órfão `orchestrator-dynamic/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)