### PR TITLE
fix(orchestrator): desabilitar spiffe no overlay staging (alinhar com prod)

### DIFF
--- a/environments/staging/helm-values/orchestrator-dynamic-values.yaml
+++ b/environments/staging/helm-values/orchestrator-dynamic-values.yaml
@@ -17,6 +17,6 @@ config:
     failOpen: false
 
   spiffe:
-    enabled: true
+    enabled: false  # Desabilitado - servidor SPIRE não está rodando no cluster
 
 environment: staging


### PR DESCRIPTION
## Sumário

Causa-raiz dos pods `orchestrator-dynamic` presos em `Init` no namespace `neural-hive` (release Helm `failed`).

O overlay `environments/staging/helm-values/orchestrator-dynamic-values.yaml` tinha `spiffe.enabled: true`, sobrepondo o `false` do chart base. Isso monta o volume `spire-agent-socket` (hostPath `/run/spire/sockets`), mas o **SPIRE foi removido do cluster** → o mount falha e o pod nunca sai de `Init`.

O overlay de **prod já tinha sido corrigido** para `false`; o **staging ficou por alinhar**. Como o pipeline `deploy-after-build` usa staging para este cluster, os deploys ficavam `failed` (rate-limiter durante o wait dos pods que nunca ficavam ready).

## Alteração
`spiffe.enabled: true → false` no overlay staging (mesmo valor e comentário do prod).

## Efeito esperado
Próximo deploy remove o volume SPIRE → os pods arrancam (servidor corre insecure, coerente com o contrato gRPC :50053 do ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)