### PR TITLE
fix(kafka): resolver CrashLoopBackOff do entity-operator (CPU starvation)

### DIFF
--- a/k8s/kafka-local.yaml
+++ b/k8s/kafka-local.yaml
@@ -75,21 +75,23 @@ spec:
       min.insync.replicas: 2
   entityOperator:
     topicOperator:
+      # CPU aumentado (200m->1000m) para acelerar arranque da JVM e evitar
+      # falha da startup probe (connection refused na :8080) sob CPU starvation.
       resources:
         requests:
-          memory: 256Mi
-          cpu: 100m
+          memory: 384Mi
+          cpu: 250m
         limits:
-          memory: 512Mi
-          cpu: 200m
+          memory: 768Mi
+          cpu: 1000m
     userOperator:
       resources:
         requests:
-          memory: 256Mi
-          cpu: 100m
+          memory: 384Mi
+          cpu: 250m
         limits:
-          memory: 512Mi
-          cpu: 200m
+          memory: 768Mi
+          cpu: 1000m
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic


### PR DESCRIPTION
## Summary

O `topic-operator` do Kafka estava em **CrashLoopBackOff há 13 dias** (749 restarts). A startup probe falhava (`connection refused` na :8080) porque a JVM não arrancava dentro dos 135s da probe sob **CPU starvation** (limite 200m). Isto bloqueava a reconciliação do cluster-operator (Kafka CR `NotReady`/`TimeoutException`, gen 11≠12) num deadlock.

## Changes Made

- `k8s/kafka-local.yaml`: recursos do **topic/user operator** aumentados
  - limits: `200m CPU / 512Mi` → `1000m CPU / 768Mi`
  - requests: `100m / 256Mi` → `250m / 384Mi`

## Testing (evidência no cluster ao vivo)

| Item | Antes | Depois |
|------|-------|--------|
| Pod entity-operator | CrashLoopBackOff, 753 restarts | **1/1 Running, 0 restarts** |
| Arranque JVM | timeout >135s | <60s |
| Kafka CR | `NotReady` (gen 11) | **`Ready: True` (gen 12)** |
| Tópicos | reconciliação parada | **17 reconciliados** |

Fix já aplicado ao cluster (patch ao vivo) e persistido na fonte versionada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)