### PR TITLE
fix(approval): resolver HTTP 500 na aprovação (datetime tz-naive/aware)

### DIFF
--- a/services/approval-service/src/services/approval_service.py
+++ b/services/approval-service/src/services/approval_service.py
@@ -686,7 +686,11 @@ class ApprovalService:
 
         # Emite metricas
         duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-        time_to_decision = (decision.approved_at - approval.requested_at).total_seconds()
+        # requested_at vindo do MongoDB e tz-naive; normaliza para UTC antes de subtrair
+        requested_at = approval.requested_at
+        if requested_at.tzinfo is None:
+            requested_at = requested_at.replace(tzinfo=timezone.utc)
+        time_to_decision = (decision.approved_at - requested_at).total_seconds()
 
         self.metrics.increment_approvals_total("approved", approval.risk_band)
         self.metrics.observe_processing_duration(duration, "approved")
@@ -771,7 +775,11 @@ class ApprovalService:
 
         # Emite metricas
         duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-        time_to_decision = (decision.approved_at - approval.requested_at).total_seconds()
+        # requested_at vindo do MongoDB e tz-naive; normaliza para UTC antes de subtrair
+        requested_at = approval.requested_at
+        if requested_at.tzinfo is None:
+            requested_at = requested_at.replace(tzinfo=timezone.utc)
+        time_to_decision = (decision.approved_at - requested_at).total_seconds()
 
         self.metrics.increment_approvals_total("rejected", approval.risk_band)
         self.metrics.observe_processing_duration(duration, "rejected")


### PR DESCRIPTION
## Summary

Durante um **smoke E2E do pipeline cognitivo** ao vivo, a aprovação de planos `review_required` falhava com **HTTP 500: `can't subtract offset-naive and offset-aware datetimes`**, bloqueando todo o fluxo de aprovação manual (FLUXO C1/C2 → C3-C6).

**Causa raiz:** `approval.requested_at` vem do MongoDB como `datetime` **tz-naive**; `decision.approved_at` é **tz-aware** (`datetime.now(timezone.utc)`). A subtração para `time_to_decision` rebenta.

## Changes Made

- `approval_service.py` (~689 approve, ~776 reject): normaliza `requested_at` para UTC quando tz-naive antes da subtração, seguindo o padrão já usado em `metrics.py:247` e `retraining_scheduler.py:449`.

## Testing

- Reprodução isolada: `TypeError` antes → `time_to_decision` calculado depois ✅
- `black --check`: sem alterações ✅
- **27 testes unitários** (`tests/services/test_approval_service.py`) verdes ✅
- `py_compile` OK ✅

## Evidência E2E (cluster ao vivo)

| Fluxo | Estado |
|-------|--------|
| A Gateway→Kafka | ✅ intent SECURITY, confidence 0.95 |
| B STE→plans.ready | ✅ plano com 8 tasks |
| C Consensus (7 especialistas) | ✅ decisão `review_required` |
| C1 Pedido de aprovação | ✅ persistido (`plan_approvals`) |
| **C1/C2 Aprovar plano** | ❌ **HTTP 500 (este fix)** |

⚠️ Requer rebuild+deploy (CI/CD) para validar a aprovação ao vivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)