### PR TITLE
fix: 4 bugs colaterais do pipeline cognitivo (smoke E2E)

### DIFF
--- a/services/approval-service/src/clients/feature_store_client.py
+++ b/services/approval-service/src/clients/feature_store_client.py
@@ -78,7 +78,13 @@ class FeatureStoreClient:
                 return None
 
         except httpx.RequestError as e:
-            logger.error("Erro de requisição ao Feature Store", plan_id=plan_id, error=str(e))
+            # Falha de DNS/conexão (ex.: feature-store inexistente no cluster) é degradação
+            # esperada: degradamos para WARNING e seguimos sem features ML via fallback.
+            logger.warning(
+                "Feature Store indisponível (degradação esperada): a continuar sem features ML",
+                plan_id=plan_id,
+                error=str(e),
+            )
             return None
         except Exception as e:
             logger.error("Erro ao buscar features", plan_id=plan_id, error=str(e))
@@ -123,7 +129,13 @@ class FeatureStoreClient:
                 return None
 
         except httpx.RequestError as e:
-            logger.error("Erro de requisição ao Feature Store", plan_id=plan_id, error=str(e))
+            # Falha de DNS/conexão (ex.: feature-store inexistente no cluster) é degradação
+            # esperada: degradamos para WARNING e seguimos sem features ML via fallback.
+            logger.warning(
+                "Feature Store indisponível (degradação esperada): a continuar sem features ML",
+                plan_id=plan_id,
+                error=str(e),
+            )
             return None
         except Exception as e:
             logger.error("Erro ao computar features", plan_id=plan_id, error=str(e))
@@ -156,6 +168,14 @@ class FeatureStoreClient:
                 )
                 return {}
 
+        except httpx.RequestError as e:
+            # Falha de DNS/conexão (ex.: feature-store inexistente no cluster) é degradação
+            # esperada: degradamos para WARNING e seguimos sem features ML via fallback.
+            logger.warning(
+                "Feature Store indisponível (degradação esperada): a continuar sem features ML",
+                error=str(e),
+            )
+            return {}
         except Exception as e:
             logger.error("Erro ao buscar features múltiplas", error=str(e))
             return {}

--- a/services/approval-service/src/observability/metrics.py
+++ b/services/approval-service/src/observability/metrics.py
@@ -243,6 +243,12 @@ class NeuralHiveMetrics:
                     risk_band = item["_id"]
                     oldest = item.get("oldest_requested_at")
                     if oldest:
+                        # MongoDB pode devolver a data como string ISO; converte
+                        # para datetime antes de aceder a tzinfo para evitar AttributeError
+                        if isinstance(oldest, str):
+                            # Normaliza o sufixo 'Z' (Zulu) para offset explícito '+00:00',
+                            # pois datetime.fromisoformat não o parseia em Python < 3.11
+                            oldest = datetime.fromisoformat(oldest.replace("Z", "+00:00"))
                         # Calcula idade em segundos
                         if oldest.tzinfo is None:
                             oldest = oldest.replace(tzinfo=timezone.utc)

--- a/services/consensus-engine/src/clients/queen_agent_grpc_client.py
+++ b/services/consensus-engine/src/clients/queen_agent_grpc_client.py
@@ -309,13 +309,16 @@ class QueenAgentGrpcClient:
 
         request = queen_agent_pb2.GetSystemStatusRequest()
 
+        # Timeout configurável; check secundário de saúde, mais tolerante que a chamada principal
+        status_timeout_s = getattr(self.config, "queen_agent_status_timeout_ms", 30000) / 1000.0
+
         # Função interna para a chamada gRPC
         async def _grpc_call():
             for attempt in range(MAX_RETRIES):
                 try:
                     metadata = await self._get_grpc_metadata()
                     response = await self.stub.GetSystemStatus(
-                        request, metadata=metadata, timeout=10.0
+                        request, metadata=metadata, timeout=status_timeout_s
                     )
 
                     return {
@@ -332,7 +335,8 @@ class QueenAgentGrpcClient:
                         grpc.StatusCode.UNAVAILABLE,
                         grpc.StatusCode.DEADLINE_EXCEEDED,
                     ]
-                    logger.error(
+                    # Check secundário de saúde: falha é degradação esperada, não erro crítico
+                    logger.warning(
                         "grpc_get_system_status_failed",
                         error=str(e),
                         code=e.code().name if hasattr(e, "code") else "UNKNOWN",

--- a/services/consensus-engine/src/config/settings.py
+++ b/services/consensus-engine/src/config/settings.py
@@ -108,6 +108,11 @@ class Settings(BaseSettings):
         default="queen-agent.neural-hive.svc.cluster.local", description="Host do Queen Agent gRPC"
     )
     queen_agent_grpc_port: int = Field(default=50053, description="Porta do Queen Agent gRPC", gt=0)
+    # Timeout do check secundário get_system_status (mais tolerante que a chamada principal,
+    # pois é métrica de saúde não-bloqueante e o Queen Agent pode estar sob carga)
+    queen_agent_status_timeout_ms: int = Field(
+        default=30000, description="Timeout (ms) do get_system_status do Queen Agent", gt=0
+    )
 
     # gRPC Client (Analyst Agent)
     analyst_agent_grpc_host: str = Field(

--- a/services/consensus-engine/src/services/fallback_storage.py
+++ b/services/consensus-engine/src/services/fallback_storage.py
@@ -394,7 +394,16 @@ class FallbackStorage:
             restored = 0
             async for doc in cursor:
                 key = doc["key"]
-                value = doc["value"]
+                value = doc.get("value")
+                if value is None:
+                    # Docs de lista (type="list") usam o campo "items" e não têm "value";
+                    # são saltados nesta sincronização simples key/value.
+                    logger.debug(
+                        "Sync: doc sem campo 'value' ignorado",
+                        key=key,
+                        doc_type=doc.get("type"),
+                    )
+                    continue
 
                 # Verificar se já existe no Redis
                 try:


### PR DESCRIPTION
## Summary

Quatro bugs colaterais (ruído de ERROR e falhas silenciosas) detetados ao rastrear uma intenção real fim-a-fim no pipeline cognitivo. Corrigidos com pipeline multi-agente rigoroso: **Análise → Dev → Auditoria de Qualidade → Auditoria de Completude → Remediação dirigida**.

## Bugs corrigidos

| # | Serviço | Ficheiro | Problema → Fix |
|---|---------|----------|----------------|
| 1 | approval-service | feature_store_client.py | Feature Store inexistente no cluster → log ERROR por pedido. httpx.RequestError → WARNING + fallback, nos 3 métodos |
| 2 | approval-service | metrics.py | gauge falhava com "'str' object has no attribute 'tzinfo'" → converte str→datetime, normaliza sufixo Zulu "Z"→"+00:00" (Python 3.10) |
| 3 | consensus-engine | fallback_storage.py | sync Mongo→Redis com KeyError "value" → doc.get("value") + skip/DEBUG para docs type=list |
| 4 | consensus-engine | queen_agent_grpc_client.py + settings.py | get_system_status DEADLINE_EXCEEDED recorrente → timeout 10s→configurável 30s + ERROR→WARNING |

## Auditoria do pipeline (achados reais)

- A **auditoria de qualidade** apanhou um FAIL no bug 2: o fix inicial usava datetime.fromisoformat sem normalizar o sufixo Zulu, que levanta ValueError em Python 3.10 (só suportado em 3.11+) — a métrica continuaria silenciosamente quebrada. A **remediação dirigida** corrigiu para oldest.replace("Z", "+00:00").
- A **auditoria de completude** apanhou um gap no bug 1: o 3º método (get_features_by_plan_ids) não tinha o mesmo handler httpx.RequestError — remediado para consistência.

## Testing

- py_compile (5 ficheiros) e black: OK
- approval-service: **108 testes** verdes
- consensus-engine: **76 testes** verdes (2 falhas pré-existentes de stub protobuf dessincronizado, confirmadas no baseline, alheias a estes fixes)

⚠️ Requer rebuild+deploy (CI/CD) para confirmar a redução de ruído nos logs ao vivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
