### PR TITLE
fix(worker-agents): adicionar PyJWT em falta (ModuleNotFoundError jwt)

### DIFF
--- a/services/worker-agents/requirements.txt
+++ b/services/worker-agents/requirements.txt
@@ -2,3 +2,4 @@
 -r ../../requirements-base.txt
 
 # Service-specific dependencies (a serem adicionadas manualmente)
+PyJWT[crypto]==2.10.1  # usado em clients/execution_ticket_client.py e api/http_server.py


### PR DESCRIPTION
## Resumo
worker-agents em CrashLoopBackOff com `ModuleNotFoundError: No module named 'jwt'` ao escalar de 0→2 réplicas (necessário para validar C4-C6 do smoke E2E).

## Causa
Import `jwt` em `clients/execution_ticket_client.py:7` e `api/http_server.py` introduzido em ae075b0f, mas a dependência nunca foi declarada no requirements. Deployment estava a 0 réplicas há 121d → crash nunca exercido.

## Fix
Adiciona `PyJWT[crypto]==2.10.1` (mesma versão do approval-service; extra `[crypto]` necessário para `jwt.algorithms`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)