### PR TITLE
fix(worker-agents): corrigir imports absolutos 'from clients.' → 'from src.clients.'

### DIFF
--- a/services/worker-agents/src/executors/deploy_executor.py
+++ b/services/worker-agents/src/executors/deploy_executor.py
@@ -2,7 +2,7 @@ import asyncio
 import random
 from typing import Any
 
-from clients.argocd_client import (
+from src.clients.argocd_client import (
     ApplicationCreateRequest,
     ApplicationDestination,
     ApplicationMetadata,
@@ -13,7 +13,7 @@ from clients.argocd_client import (
     ArgoCDTimeoutError,
     SyncPolicy,
 )
-from clients.flux_client import (
+from src.clients.flux_client import (
     FluxAPIError,
     FluxClient,
     FluxTimeoutError,

--- a/services/worker-agents/src/executors/execute_executor.py
+++ b/services/worker-agents/src/executors/execute_executor.py
@@ -108,7 +108,7 @@ class ExecuteExecutor(BaseTaskExecutor):
         self, ticket_id: str, parameters: dict[str, Any], span
     ) -> dict[str, Any]:
         """Executa via Kubernetes Jobs."""
-        from clients.k8s_jobs_client import K8sJobRequest, K8sJobStatus, K8sResourceRequirements
+        from src.clients.k8s_jobs_client import K8sJobRequest, K8sJobStatus, K8sResourceRequirements
 
         self.log_execution(ticket_id, "k8s_execution_starting", runtime="k8s")
 
@@ -196,7 +196,7 @@ class ExecuteExecutor(BaseTaskExecutor):
         self, ticket_id: str, parameters: dict[str, Any], span
     ) -> dict[str, Any]:
         """Executa via Docker container."""
-        from clients.docker_runtime_client import (
+        from src.clients.docker_runtime_client import (
             DockerExecutionRequest,
             DockerNetworkMode,
             ResourceLimits,
@@ -280,7 +280,7 @@ class ExecuteExecutor(BaseTaskExecutor):
         self, ticket_id: str, parameters: dict[str, Any], span
     ) -> dict[str, Any]:
         """Executa via AWS Lambda."""
-        from clients.lambda_runtime_client import LambdaInvocationRequest, LambdaPayload
+        from src.clients.lambda_runtime_client import LambdaInvocationRequest, LambdaPayload
 
         self.log_execution(ticket_id, "lambda_execution_starting", runtime="lambda")
 
@@ -350,7 +350,7 @@ class ExecuteExecutor(BaseTaskExecutor):
         self, ticket_id: str, parameters: dict[str, Any], span
     ) -> dict[str, Any]:
         """Executa localmente via subprocess."""
-        from clients.local_runtime_client import LocalExecutionRequest
+        from src.clients.local_runtime_client import LocalExecutionRequest
 
         self.log_execution(ticket_id, "local_execution_starting", runtime="local")
 

--- a/services/worker-agents/src/executors/test_executor.py
+++ b/services/worker-agents/src/executors/test_executor.py
@@ -70,7 +70,7 @@ class TestExecutor(BaseTaskExecutor):
         # Fallback: tentar criar clients a partir do config se nao fornecidos
         if self.github_actions_client is None and getattr(config, "github_actions_enabled", False):
             try:
-                from clients.github_actions_client import GitHubActionsClient
+                from src.clients.github_actions_client import GitHubActionsClient
 
                 self.github_actions_client = GitHubActionsClient.from_env(config)
             except Exception:
@@ -386,7 +386,7 @@ class TestExecutor(BaseTaskExecutor):
         Returns:
             Resultado da execucao
         """
-        from clients.github_actions_client import GitHubActionsAPIError, GitHubActionsTimeoutError
+        from src.clients.github_actions_client import GitHubActionsAPIError, GitHubActionsTimeoutError
 
         self.log_execution(
             ticket_id,
@@ -571,7 +571,7 @@ class TestExecutor(BaseTaskExecutor):
         Returns:
             Resultado da execucao
         """
-        from clients.gitlab_ci_client import GitLabCIAPIError, GitLabCITimeoutError
+        from src.clients.gitlab_ci_client import GitLabCIAPIError, GitLabCITimeoutError
 
         self.log_execution(
             ticket_id,
@@ -780,7 +780,7 @@ class TestExecutor(BaseTaskExecutor):
         Returns:
             Resultado da execucao
         """
-        from clients.jenkins_client import JenkinsAPIError, JenkinsTimeoutError
+        from src.clients.jenkins_client import JenkinsAPIError, JenkinsTimeoutError
 
         self.log_execution(ticket_id, "test_jenkins_started", job_name=parameters.get("job_name"))
 

--- a/services/worker-agents/src/executors/validate_executor.py
+++ b/services/worker-agents/src/executors/validate_executor.py
@@ -57,7 +57,7 @@ class ValidateExecutor(BaseTaskExecutor):
         self.logger = logger.bind(executor="ValidateExecutor")
 
         try:
-            from clients.sonarqube_client import SonarQubeClient
+            from src.clients.sonarqube_client import SonarQubeClient
 
             self.sonarqube_client = (
                 SonarQubeClient.from_env(config)
@@ -67,7 +67,7 @@ class ValidateExecutor(BaseTaskExecutor):
         except Exception:
             self.sonarqube_client = None
         try:
-            from clients.snyk_client import SnykClient
+            from src.clients.snyk_client import SnykClient
 
             self.snyk_client = (
                 SnykClient.from_env(config) if getattr(config, "snyk_enabled", False) else None
@@ -75,7 +75,7 @@ class ValidateExecutor(BaseTaskExecutor):
         except Exception:
             self.snyk_client = None
         try:
-            from clients.checkov_client import CheckovClient
+            from src.clients.checkov_client import CheckovClient
 
             self.checkov_client = (
                 CheckovClient(config) if getattr(config, "checkov_enabled", False) else None
@@ -379,7 +379,7 @@ class ValidateExecutor(BaseTaskExecutor):
         Returns:
             Resultado da validacao
         """
-        from clients.opa_client import (
+        from src.clients.opa_client import (
             OPAAPIError,
             OPATimeoutError,
             OPAValidationError,


### PR DESCRIPTION
## Resumo
worker-agents crashava no arranque: `ModuleNotFoundError: No module named 'clients'` (deploy_executor.py:5), bloqueando C4-C6 do smoke E2E.

## Causa
App corre como `python -m src.main` com `PYTHONPATH=/app` → módulos locais são `src.clients.*`. `deploy_executor` importava `from clients.argocd_client` no top-level (executado via executors/__init__.py). execute/test/validate tinham o mesmo bug em imports lazy (latentes).

## Fix
Sweep de 14 ocorrências `from clients.` → `from src.clients.` em 4 ficheiros, consistente com o precedente `from src.config` em clients/vault_integration.py.

Bugs nunca exercidos: deployment esteve a 0 réplicas há 121d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)