### PR TITLE
feat(orchestration): camada de tradução semântica→técnica de parâmetros

### DIFF
--- a/libraries/neural_hive_integration/neural_hive_integration/orchestration/flow_c_orchestrator.py
+++ b/libraries/neural_hive_integration/neural_hive_integration/orchestration/flow_c_orchestrator.py
@@ -29,6 +29,7 @@ from neural_hive_integration.clients.worker_agent_client import WorkerAgentClien
 from neural_hive_integration.clients.sla_management_client import SLAManagementClient
 from neural_hive_integration.models.flow_c_context import FlowCContext, FlowCStep, FlowCResult
 from neural_hive_integration.telemetry.flow_c_telemetry import FlowCTelemetryPublisher
+from neural_hive_integration.orchestration.parameter_resolver import resolve_ticket_parameters
 from neural_hive_resilience.circuit_breaker import MonitoredCircuitBreaker, CircuitBreakerError
 from aiokafka import AIOKafkaProducer
 import os
@@ -930,7 +931,16 @@ class FlowCOrchestrator:
                     "consistency": "EVENTUAL",
                     "durability": "PERSISTENT",
                 },
-                "parameters": task.get("parameters", {}),
+                # Tradução semântica→técnica dos parâmetros (ver parameter_resolver):
+                # o caminho heurístico do STE gera params semânticos (objective/entities)
+                # que os executores não conseguem processar. Resolvemos para o contrato
+                # técnico antes de despachar o ticket. Idempotente para o caminho template.
+                "parameters": resolve_ticket_parameters(
+                    normalized_task_type,
+                    task.get("parameters", {}),
+                    domain=(task.get("metadata", {}) or {}).get("domain")
+                    or cognitive_plan.get("original_domain"),
+                ),
                 "required_capabilities": task.get(
                     "required_capabilities",
                     task.get("capabilities", ["python", "read", "write", "compute", "code"]),

--- a/libraries/neural_hive_integration/neural_hive_integration/orchestration/parameter_resolver.py
+++ b/libraries/neural_hive_integration/neural_hive_integration/orchestration/parameter_resolver.py
@@ -1,0 +1,152 @@
+"""
+Resolução de parâmetros semânticos → técnicos para execution tickets.
+
+Contexto do problema (lacuna arquitetural):
+O STE decompõe intents por dois caminhos com contratos de `parameters` distintos
+para o mesmo `task_type`:
+  - Caminho template (decomposition_templates): gera parâmetros TÉCNICOS prontos
+    (ex.: query → {collection, filter, limit}).
+  - Caminho heurístico (dag_generator._create_task_from_objective): gera parâmetros
+    SEMÂNTICOS (ex.: query → {objective, entities, constraints}).
+
+A cadeia de orquestração copiava os `parameters` tal-qual para o ExecutionTicket,
+e os executores do worker exigem o contrato técnico (ex.: query_executor exige
+`collection`). Quando uma intent caía no caminho heurístico, o ticket falhava com
+`Missing required parameters: ['collection']`.
+
+Este módulo é a camada de tradução central: recebe os `parameters` de uma task e,
+quando estão em forma semântica, completa-os com o contrato técnico que o executor
+espera. É **idempotente** — se os parâmetros já são técnicos (caminho template), são
+devolvidos sem alteração.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Database onde residem as collections de conhecimento/contexto do NHM.
+# (O default do query_executor é `neural_hive_workers`, que só contém a DLQ;
+# os dados de domínio estão em `neural_hive`.)
+DEFAULT_QUERY_DATABASE = "neural_hive"
+
+# Mapeamento domínio semântico → collection MongoDB de contexto.
+# Collections confirmadas em `neural_hive`. O fallback `operational_context`
+# existe e serve de alvo genérico para queries de análise.
+DOMAIN_COLLECTION_MAP = {
+    "security": "security_incidents",
+    "architecture": "operational_context",
+    "technical": "operational_context",
+    "business": "insights",
+    "data": "insights",
+    "evolution": "optimization_ledger",
+    "behavior": "specialist_feedback",
+    "quality": "validation_audit",
+    "performance": "telemetry_buffer",
+    "operational": "operational_context",
+}
+FALLBACK_COLLECTION = "operational_context"
+
+# Limite conservador para queries best-effort (devolve contexto recente sem
+# sobrecarregar). O caminho template define o seu próprio limit, que é respeitado.
+DEFAULT_QUERY_LIMIT = 10
+
+
+def _normalize_entities(raw: Any) -> list[str]:
+    """Normaliza o campo `entities` para uma lista de strings.
+
+    As entities podem chegar como lista de dicts (`[{"value": "OAuth2"}, ...]`),
+    lista de strings, ou string JSON serializada (efeito do schema Avro
+    `map<string,string>`). Devolve sempre uma lista de strings limpa.
+    """
+    if not raw:
+        return []
+    # String serializada (ex.: "[{'value': 'OAuth2', ...}]") → tentar desserializar.
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw.replace("'", '"'))
+        except (json.JSONDecodeError, ValueError):
+            return [raw] if raw.strip() else []
+    if isinstance(raw, dict):
+        raw = [raw]
+    result: list[str] = []
+    for item in raw if isinstance(raw, list) else []:
+        if isinstance(item, dict):
+            value = item.get("value") or item.get("name") or item.get("text")
+            if value:
+                result.append(str(value))
+        elif item:
+            result.append(str(item))
+    return result
+
+
+def _resolve_query_parameters(parameters: dict[str, Any], domain: str | None) -> dict[str, Any]:
+    """Completa parâmetros de uma task `query` com o contrato técnico do executor.
+
+    Idempotente: se `collection` já está presente (caminho template), não altera nada.
+    Caso contrário, deriva `query_type`/`collection`/`filter`/`limit`/`database` a
+    partir do domínio e das entities (best-effort).
+    """
+    # Caminho template já produziu contrato técnico — não tocar.
+    if parameters.get("collection"):
+        return parameters
+
+    domain_key = (domain or "").strip().lower()
+    collection = DOMAIN_COLLECTION_MAP.get(domain_key, FALLBACK_COLLECTION)
+    entities = _normalize_entities(parameters.get("entities"))
+
+    resolved = dict(parameters)
+    resolved["query_type"] = parameters.get("query_type", "mongodb")
+    resolved["collection"] = collection
+    resolved["database"] = parameters.get("database", DEFAULT_QUERY_DATABASE)
+    # Filtro best-effort: vazio devolve o contexto mais recente da collection do
+    # domínio (garante execução com sucesso). As entities resolvidas ficam
+    # registadas para rastreabilidade/observabilidade.
+    resolved.setdefault("filter", {})
+    resolved.setdefault("limit", DEFAULT_QUERY_LIMIT)
+    resolved["resolved_from_entities"] = entities
+
+    logger.info(
+        "query_parameters_resolved",
+        domain=domain_key or "unknown",
+        collection=collection,
+        database=resolved["database"],
+        entities_count=len(entities),
+    )
+    return resolved
+
+
+def resolve_ticket_parameters(
+    task_type: str,
+    parameters: dict[str, Any] | None,
+    *,
+    domain: str | None = None,
+) -> dict[str, Any]:
+    """Resolve os `parameters` de uma task para o contrato técnico do executor.
+
+    Ponto único de tradução semântica→técnica, chamado na geração de tickets
+    (tanto no caminho Temporal como no flow_c/Kafka).
+
+    Args:
+        task_type: Tipo da task já normalizado (ex.: "QUERY", "TRANSFORM").
+        parameters: Parâmetros da task vindos do CognitivePlan (semânticos ou técnicos).
+        domain: Domínio semântico da task (ex.: "security"), usado no mapeamento.
+
+    Returns:
+        Parâmetros completados com o contrato técnico. Idempotente para parâmetros
+        já técnicos e para task_types sem resolução específica.
+    """
+    params = dict(parameters or {})
+    normalized = (task_type or "").strip().upper()
+
+    if normalized == "QUERY":
+        return _resolve_query_parameters(params, domain)
+
+    # Outros task_types (TRANSFORM/VALIDATE/EXECUTE/...) ainda não têm resolução
+    # semântica dedicada; o caminho template já fornece os seus parâmetros técnicos
+    # (input_data, policy_path) e os executores aplicam defaults seguros.
+    return params

--- a/libraries/neural_hive_integration/tests/test_parameter_resolver.py
+++ b/libraries/neural_hive_integration/tests/test_parameter_resolver.py
@@ -1,0 +1,129 @@
+"""
+Testes unitários para a camada de tradução semântica→técnica de parâmetros.
+
+Cobre a lacuna corrigida: o caminho heurístico do STE gera parâmetros semânticos
+(objective/entities/constraints) que os executores do worker não conseguem processar
+(query_executor exige `collection`). O resolver completa-os para o contrato técnico.
+"""
+
+import pytest
+
+from neural_hive_integration.orchestration.parameter_resolver import (
+    DEFAULT_QUERY_DATABASE,
+    DEFAULT_QUERY_LIMIT,
+    FALLBACK_COLLECTION,
+    resolve_ticket_parameters,
+)
+
+
+class TestResolveQueryHeuristico:
+    """Caminho heurístico: params semânticos → contrato técnico."""
+
+    def test_query_security_mapeia_para_security_incidents(self):
+        params = {"objective": "query", "entities": ["OAuth2", "MFA"], "constraints": {}}
+        result = resolve_ticket_parameters("QUERY", params, domain="SECURITY")
+
+        assert result["query_type"] == "mongodb"
+        assert result["collection"] == "security_incidents"
+        assert result["database"] == DEFAULT_QUERY_DATABASE
+        assert result["limit"] == DEFAULT_QUERY_LIMIT
+        assert result["filter"] == {}
+        assert result["resolved_from_entities"] == ["OAuth2", "MFA"]
+
+    def test_dominio_desconhecido_usa_fallback(self):
+        result = resolve_ticket_parameters("QUERY", {"objective": "q"}, domain=None)
+        assert result["collection"] == FALLBACK_COLLECTION
+
+    @pytest.mark.parametrize(
+        ("domain", "expected"),
+        [
+            ("security", "security_incidents"),
+            ("business", "insights"),
+            ("evolution", "optimization_ledger"),
+            ("behavior", "specialist_feedback"),
+            ("architecture", "operational_context"),
+        ],
+    )
+    def test_mapeamento_por_dominio(self, domain, expected):
+        result = resolve_ticket_parameters("QUERY", {"objective": "q"}, domain=domain)
+        assert result["collection"] == expected
+
+    def test_dominio_case_insensitive(self):
+        result = resolve_ticket_parameters("QUERY", {"objective": "q"}, domain="Security")
+        assert result["collection"] == "security_incidents"
+
+
+class TestNormalizacaoEntities:
+    """O campo entities pode chegar em vários formatos (efeito do schema Avro)."""
+
+    def test_string_serializada_aspas_simples(self):
+        # Formato observado no smoke real (str com aspas simples).
+        params = {"objective": "q", "entities": "[{'value': 'OAuth2'}, {'value': 'MFA'}]"}
+        result = resolve_ticket_parameters("QUERY", params, domain="security")
+        assert result["resolved_from_entities"] == ["OAuth2", "MFA"]
+
+    def test_lista_de_dicts(self):
+        params = {"objective": "q", "entities": [{"value": "A"}, {"name": "B"}]}
+        result = resolve_ticket_parameters("QUERY", params, domain="security")
+        assert result["resolved_from_entities"] == ["A", "B"]
+
+    def test_lista_de_strings(self):
+        params = {"objective": "q", "entities": ["X", "Y"]}
+        result = resolve_ticket_parameters("QUERY", params, domain="security")
+        assert result["resolved_from_entities"] == ["X", "Y"]
+
+    def test_entities_vazio_ou_ausente(self):
+        result = resolve_ticket_parameters("QUERY", {"objective": "q"}, domain="security")
+        assert result["resolved_from_entities"] == []
+
+
+class TestIdempotencia:
+    """Caminho template (params já técnicos) não deve ser alterado."""
+
+    def test_query_com_collection_nao_e_alterada(self):
+        params = {"collection": "ldap", "filter": {"x": 1}, "limit": 100}
+        result = resolve_ticket_parameters("QUERY", params, domain="SECURITY")
+        assert result == params
+
+    def test_query_type_existente_preservado(self):
+        params = {"query_type": "neo4j", "cypher_query": "MATCH (n) RETURN n", "collection": "x"}
+        result = resolve_ticket_parameters("QUERY", params, domain="security")
+        assert result["query_type"] == "neo4j"
+
+    def test_database_explicito_preservado(self):
+        params = {"objective": "q", "database": "custom_db"}
+        result = resolve_ticket_parameters("QUERY", params, domain="security")
+        assert result["database"] == "custom_db"
+
+
+class TestOutrosTaskTypes:
+    """Task types sem resolução dedicada passam intactos."""
+
+    @pytest.mark.parametrize("task_type", ["TRANSFORM", "VALIDATE", "EXECUTE", "BUILD", "DEPLOY"])
+    def test_passa_intacto(self, task_type):
+        params = {"policy_path": "/x", "input_data": {"a": 1}}
+        result = resolve_ticket_parameters(task_type, params, domain="security")
+        assert result == params
+
+    def test_task_type_lowercase_normalizado(self):
+        # O dispatcher normaliza para upper; "query" deve ser tratado como QUERY.
+        result = resolve_ticket_parameters("query", {"objective": "q"}, domain="security")
+        assert result["collection"] == "security_incidents"
+
+
+class TestEntradasDegeneradas:
+    """Robustez a entradas nulas/vazias."""
+
+    def test_parameters_none(self):
+        result = resolve_ticket_parameters("QUERY", None, domain="security")
+        assert result["collection"] == "security_incidents"
+
+    def test_parameters_vazio(self):
+        result = resolve_ticket_parameters("QUERY", {}, domain="security")
+        assert result["collection"] == "security_incidents"
+
+    def test_nao_muta_input_original(self):
+        params = {"objective": "q", "entities": ["A"]}
+        original = dict(params)
+        resolve_ticket_parameters("QUERY", params, domain="security")
+        assert params == original  # input não foi mutado

--- a/services/orchestrator-dynamic/src/activities/ticket_generation.py
+++ b/services/orchestrator-dynamic/src/activities/ticket_generation.py
@@ -11,6 +11,7 @@ import structlog
 from pymongo.errors import PyMongoError
 from temporalio import activity
 
+from neural_hive_integration.orchestration.parameter_resolver import resolve_ticket_parameters
 from neural_hive_resilience.circuit_breaker import CircuitBreakerError
 
 logger = structlog.get_logger()
@@ -240,7 +241,15 @@ async def generate_execution_tickets(
                     "consistency": consistency,
                     "durability": "PERSISTENT",
                 },
-                "parameters": task.get("parameters", {}),
+                # Tradução semântica→técnica dos parâmetros antes do despacho
+                # (ver neural_hive_integration.orchestration.parameter_resolver).
+                # Idempotente para parâmetros já técnicos (caminho template do STE).
+                "parameters": resolve_ticket_parameters(
+                    task.get("task_type", "EXECUTE"),
+                    task.get("parameters", {}),
+                    domain=(task.get("metadata", {}) or {}).get("domain")
+                    or cognitive_plan.get("original_domain"),
+                ),
                 "required_capabilities": task.get("required_capabilities", []),
                 "security_level": cognitive_plan.get("security_level", "INTERNAL"),
                 "created_at": int(datetime.now().timestamp() * 1000),

--- a/services/worker-agents/src/executors/query_executor.py
+++ b/services/worker-agents/src/executors/query_executor.py
@@ -200,7 +200,10 @@ class QueryExecutor(BaseTaskExecutor):
             skip = parameters.get("skip", 0)
 
             # Obter coleção - acessar via client para evitar issues com Motor 3.x
-            db_name = self.mongodb_client.config.mongodb_database
+            # Permite override do database via parâmetro (a camada de tradução da
+            # orquestração aponta queries semânticas para `neural_hive`, onde residem
+            # as collections de contexto); fallback para o database configurado.
+            db_name = parameters.get("database") or self.mongodb_client.config.mongodb_database
             db = self.mongodb_client.client[db_name]
             collection = db[collection_name]
 


### PR DESCRIPTION
## Problema
Query tasks falhavam com `Missing required parameters: ['collection']` (descoberto no smoke E2E). Causa raiz: o STE decompõe intents por **dois caminhos com contratos de `parameters` incompatíveis** para o mesmo `task_type`:
- **template** (`decomposition_templates`): gera params TÉCNICOS (`collection`/`filter`/`limit`)
- **heurístico** (`dag_generator._create_task_from_objective`): gera params SEMÂNTICOS (`objective`/`entities`/`constraints`)

A orquestração copiava `parameters` tal-qual (`ticket_generation.py:243`, `flow_c_orchestrator.py:933`); o `query_executor` exige o contrato técnico → falha quando a intent cai no caminho heurístico.

## Solução
`parameter_resolver.resolve_ticket_parameters()` — ponto único de tradução semântica→técnica, chamado nos **dois** caminhos de geração de tickets. Para query: mapeia `domain→collection`, define `query_type=mongodb`, `filter` best-effort, `database=neural_hive`. **Idempotente** para o caminho template. `query_executor` passa a respeitar override de `database`.

## Testes
24 testes unitários (heurístico, idempotência, normalização de entities em múltiplos formatos incl. string serializada, fallback, robustez). Todos verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)