### PR TITLE
fix(gateway): corrigir imports 'from src.' que impediam arranque

### DIFF
--- a/services/gateway-intencoes/src/config/settings.py
+++ b/services/gateway-intencoes/src/config/settings.py
@@ -498,7 +498,7 @@ class Settings(BaseSettings):
                         # Configurar environment para VaultClient
                         import os
 
-                        from src.clients.vault_client import VaultClient
+                        from clients.vault_client import VaultClient
 
                         if self.vault_addr:
                             os.environ["VAULT_ADDR"] = self.vault_addr

--- a/services/gateway-intencoes/src/grpc_clients/nlu_client.py
+++ b/services/gateway-intencoes/src/grpc_clients/nlu_client.py
@@ -13,7 +13,7 @@ import grpc
 from config.settings import get_settings
 
 # Importar stubs gerados
-from src.proto import nlu_pb2, nlu_pb2_grpc
+from proto import nlu_pb2, nlu_pb2_grpc
 
 logger = logging.getLogger(__name__)
 settings = get_settings()

--- a/services/gateway-intencoes/src/grpc_clients/pii_client.py
+++ b/services/gateway-intencoes/src/grpc_clients/pii_client.py
@@ -13,7 +13,7 @@ import grpc
 from config.settings import get_settings
 
 # Importar stubs gerados
-from src.proto import pii_pb2, pii_pb2_grpc
+from proto import pii_pb2, pii_pb2_grpc
 
 logger = logging.getLogger(__name__)
 settings = get_settings()


### PR DESCRIPTION
## Problema
O gateway refatorado (T11) não arranca: `ModuleNotFoundError: No module named 'src'` em `grpc_clients/nlu_client.py:16`. App corre com `PYTHONPATH=/app/src` (uvicorn main:app), logo os módulos são `proto`/`clients`, não `src.proto`.

## Fix
- `grpc_clients/nlu_client.py`: `from src.proto` → `from proto`
- `grpc_clients/pii_client.py`: `from src.proto` → `from proto`
- `config/settings.py:501` (lazy): `from src.clients.vault_client` → `from clients.vault_client`

Bug nunca exercido em produção (imagem antiga 33e5e07 é anterior ao refactor T11). Descoberto ao rebuildar o gateway para corrigir o NLU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)