### PR TITLE
fix(worker-agents): aceitar metadata em update_ticket_status (TypeError two-phase F2)

### DIFF
--- a/services/worker-agents/src/clients/execution_ticket_client.py
+++ b/services/worker-agents/src/clients/execution_ticket_client.py
@@ -75,8 +75,14 @@ class ExecutionTicketClient:
         status: str,
         error_message: str | None = None,
         actual_duration_ms: int | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Atualizar status do ticket"""
+        """Atualizar status do ticket.
+
+        `metadata` é usado pelos passos F2 do two-phase commit (dedup/mark/clear)
+        para rastreamento (processing_started_at, dedup_method). Antes a sua ausência
+        na assinatura causava TypeError, quebrando o fallback MongoDB silenciosamente.
+        """
         api_status = "error"
         try:
             payload = {
@@ -84,6 +90,8 @@ class ExecutionTicketClient:
                 "error_message": error_message,
                 "actual_duration_ms": actual_duration_ms,
             }
+            if metadata is not None:
+                payload["metadata"] = metadata
 
             response = await self.client.patch(f"/api/v1/tickets/{ticket_id}/status", json=payload)
             response.raise_for_status()


### PR DESCRIPTION
## Problema
Os passos F2 do two-phase commit (dedup/mark/clear) em `execution_engine.py` (linhas 177, 237, 280) chamam `update_ticket_status(..., metadata={...})`, mas a assinatura não tinha `metadata` → **TypeError** a cada chamada. Fail-open (try/except) mascarava, mas poluía logs (`F2_mongodb_*_failed: RetryError[TypeError]`) e quebrava o dedup/mark/clear no MongoDB quando o Redis falha.

Descoberto ao validar execução multi-task (plano de 7 tasks): cascata de falhas no cleanup F2 de cada ticket.

## Fix
`metadata: dict | None = None` na assinatura + incluído no payload condicionalmente (backend ignora extra gracefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)