### PR TITLE
fix(gateway): corrigir delegação gRPC ao nlu-service (timeout + UnifiedDomain)

### DIFF
--- a/services/gateway-intencoes/src/grpc_clients/nlu_client.py
+++ b/services/gateway-intencoes/src/grpc_clients/nlu_client.py
@@ -110,7 +110,7 @@ class NLUServiceClient:
             # Chamar NLU Service - retorna ParseResponse com campo `result` (NLUResult)
             response = await asyncio.wait_for(
                 self._stub.Parse(request),
-                timeout=settings.NLU_SERVICE_TIMEOUT or 10.0,
+                timeout=settings.nlu_service_timeout or 10.0,
             )
 
             result = response.result

--- a/services/gateway-intencoes/src/services/nlu_service_adapter.py
+++ b/services/gateway-intencoes/src/services/nlu_service_adapter.py
@@ -136,11 +136,11 @@ class NLUServiceAdapter:
                 "TECHNICAL": UnifiedDomain.TECHNICAL,
                 "INFRASTRUCTURE": UnifiedDomain.INFRASTRUCTURE,
                 "SECURITY": UnifiedDomain.SECURITY,
-                "DOMAIN_UNKNOWN": UnifiedDomain.UNKNOWN,
+                "DOMAIN_UNKNOWN": UnifiedDomain.TECHNICAL,
             }
-            return domain_mapping.get(domain_str.upper(), UnifiedDomain.UNKNOWN)
+            return domain_mapping.get(domain_str.upper(), UnifiedDomain.TECHNICAL)
         except (KeyError, ValueError):
-            return UnifiedDomain.UNKNOWN
+            return UnifiedDomain.TECHNICAL
 
     def _fallback_classify(self, text: str, language: str) -> NLUResult:
         """Classificação por keywords quando NLU Service está down (INV-12)."""
@@ -154,7 +154,7 @@ class NLUServiceAdapter:
         elif any(kw in text_lower for kw in ["migrar", "legado", "migration"]):
             domain = UnifiedDomain.INFRASTRUCTURE
         else:
-            domain = UnifiedDomain.UNKNOWN
+            domain = UnifiedDomain.TECHNICAL
 
         return NLUResult(
             processed_text=text,


### PR DESCRIPTION
## Problema
O gateway refatorado nunca delegava ao nlu-service (com o fix de acentos #126):
1. `nlu_client.py:113` usava `settings.NLU_SERVICE_TIMEOUT` (inexistente; correto: `nlu_service_timeout`) → toda chamada gRPC falhava → fallback.
2. `nlu_service_adapter.py` usava `UnifiedDomain.UNKNOWN` (membro inexistente) → AttributeError → HTTP 500.

## Fix
`NLU_SERVICE_TIMEOUT`→`nlu_service_timeout`; `UnifiedDomain.UNKNOWN`→`UnifiedDomain.TECHNICAL` (4 sítios). Completa a cadeia gateway→nlu-service (#126/#127).

🤖 Generated with [Claude Code](https://claude.com/claude-code)