### PR TITLE
fix: 3 achados da validação de fluxos (dependências, query db, consensus consumer)

### DIFF
--- a/libraries/neural_hive_integration/neural_hive_integration/orchestration/flow_c_orchestrator.py
+++ b/libraries/neural_hive_integration/neural_hive_integration/orchestration/flow_c_orchestrator.py
@@ -884,6 +884,16 @@ class FlowCOrchestrator:
         sla_deadline = int(context.sla_deadline.timestamp() * 1000)
         current_timestamp = int(datetime.now(timezone.utc).timestamp() * 1000)
 
+        # Pré-gerar ticket_ids e mapear task_id->ticket_id. As dependências no
+        # cognitive_plan são task_ids (ex.: "task_5"), mas o dependency_coordinator
+        # do worker resolve dependências via get_ticket(ticket_id). Sem esta
+        # tradução, get_ticket("task_5") dá 404 → o coordinator nunca vê o estado
+        # da dependência e espera o timeout completo (~10min) em vez de prosseguir.
+        def _task_key(t: dict) -> str:
+            return t.get("task_id", t.get("id", f"task_{t.get('type', 'unknown')}"))
+
+        task_to_ticket_id = {_task_key(t): str(uuid4()) for t in tasks}
+
         for task in tasks:
             # Mapeamento de task_type do cognitive_plan para TaskType do ExecutionTicket
             task_type = task.get("type", task.get("task_type", "code_generation"))
@@ -903,21 +913,25 @@ class FlowCOrchestrator:
             priority_mapping = {"high": "HIGH", "low": "LOW", "medium": "NORMAL"}
             normalized_priority = priority_mapping.get(str(context.priority).lower(), "NORMAL")
 
+            task_key = _task_key(task)
             ticket_data = {
                 # Campos obrigatórios do schema Avro execution-ticket.avsc
-                "ticket_id": str(uuid4()),
+                "ticket_id": task_to_ticket_id[task_key],
                 "plan_id": context.plan_id,
                 "intent_id": intent_id,
                 "decision_id": context.decision_id or f"approval-{context.plan_id[:8]}",
                 "correlation_id": correlation_id,
                 "trace_id": task.get("trace_id"),
                 "span_id": task.get("span_id"),
-                "task_id": task.get(
-                    "task_id", task.get("id", f"task_{task.get('type', 'unknown')}")
-                ),
+                "task_id": task_key,
                 "task_type": normalized_task_type,
                 "description": task.get("description", ""),
-                "dependencies": task.get("dependencies", []),
+                # Traduzir dependências de task_id para ticket_id (ver map acima)
+                "dependencies": [
+                    task_to_ticket_id[dep]
+                    for dep in task.get("dependencies", [])
+                    if dep in task_to_ticket_id
+                ],
                 "status": "PENDING",
                 "priority": normalized_priority,
                 "risk_band": risk_band,

--- a/libraries/neural_hive_integration/neural_hive_integration/orchestration/parameter_resolver.py
+++ b/libraries/neural_hive_integration/neural_hive_integration/orchestration/parameter_resolver.py
@@ -87,13 +87,18 @@ def _normalize_entities(raw: Any) -> list[str]:
 def _resolve_query_parameters(parameters: dict[str, Any], domain: str | None) -> dict[str, Any]:
     """Completa parâmetros de uma task `query` com o contrato técnico do executor.
 
-    Idempotente: se `collection` já está presente (caminho template), não altera nada.
-    Caso contrário, deriva `query_type`/`collection`/`filter`/`limit`/`database` a
-    partir do domínio e das entities (best-effort).
+    - Caminho template (já tem `collection`): preserva collection/filter/limit, mas
+      garante `query_type` e `database` (o template não os fornece, pelo que a query
+      iria ao DB default `neural_hive_workers`, vazio, em vez de `neural_hive`).
+    - Caminho heurístico (sem `collection`): deriva collection/filter/limit/database
+      a partir do domínio e das entities (best-effort).
     """
-    # Caminho template já produziu contrato técnico — não tocar.
+    # Caminho template: já tem collection; apenas garantir query_type+database.
     if parameters.get("collection"):
-        return parameters
+        resolved = dict(parameters)
+        resolved.setdefault("query_type", "mongodb")
+        resolved.setdefault("database", DEFAULT_QUERY_DATABASE)
+        return resolved
 
     domain_key = (domain or "").strip().lower()
     collection = DOMAIN_COLLECTION_MAP.get(domain_key, FALLBACK_COLLECTION)

--- a/libraries/neural_hive_integration/tests/test_parameter_resolver.py
+++ b/libraries/neural_hive_integration/tests/test_parameter_resolver.py
@@ -78,12 +78,18 @@ class TestNormalizacaoEntities:
 
 
 class TestIdempotencia:
-    """Caminho template (params já técnicos) não deve ser alterado."""
+    """Caminho template: collection/filter/limit preservados; query_type/database garantidos."""
 
-    def test_query_com_collection_nao_e_alterada(self):
+    def test_query_com_collection_preserva_e_garante_db(self):
         params = {"collection": "ldap", "filter": {"x": 1}, "limit": 100}
         result = resolve_ticket_parameters("QUERY", params, domain="SECURITY")
-        assert result == params
+        # collection/filter/limit do template são preservados
+        assert result["collection"] == "ldap"
+        assert result["filter"] == {"x": 1}
+        assert result["limit"] == 100
+        # query_type e database são garantidos (template não os fornece)
+        assert result["query_type"] == "mongodb"
+        assert result["database"] == "neural_hive"
 
     def test_query_type_existente_preservado(self):
         params = {"query_type": "neo4j", "cypher_query": "MATCH (n) RETURN n", "collection": "x"}

--- a/services/consensus-engine/src/config/settings.py
+++ b/services/consensus-engine/src/config/settings.py
@@ -26,6 +26,15 @@ class Settings(BaseSettings):
     kafka_plans_topic: str = Field(default="plans.ready", description="Tópico de planos cognitivos")
     kafka_auto_offset_reset: str = Field(default="earliest", description="Auto offset reset")
     kafka_enable_auto_commit: bool = Field(default=False, description="Auto commit offsets")
+    kafka_max_poll_interval_ms: int = Field(
+        default=1800000,
+        description=(
+            "Intervalo máximo entre polls antes de o broker expulsar o consumer. "
+            "Default do confluent-kafka (5min) é insuficiente: processar uma mensagem "
+            "invoca 5 especialistas via gRPC + consolidação, podendo exceder 5min com "
+            "especialistas lentos → consumer expulso/preso até restart. 30min dá margem."
+        ),
+    )
     kafka_security_protocol: str = Field(default="PLAINTEXT", description="Security protocol")
     kafka_sasl_mechanism: Optional[str] = Field(default=None, description="SASL mechanism")
     kafka_sasl_username: Optional[str] = Field(default=None, description="SASL username")

--- a/services/consensus-engine/src/consumers/plan_consumer.py
+++ b/services/consensus-engine/src/consumers/plan_consumer.py
@@ -46,6 +46,9 @@ class PlanConsumer:
             "group.id": self.config.kafka_consumer_group_id,
             "auto.offset.reset": self.config.kafka_auto_offset_reset,
             "enable.auto.commit": self.config.kafka_enable_auto_commit,
+            # Evita expulsão do consumer durante processamento longo (5 especialistas
+            # gRPC + consolidação). Default do confluent-kafka (5min) era insuficiente.
+            "max.poll.interval.ms": self.config.kafka_max_poll_interval_ms,
         }
 
         # Configuração de segurança SASL (se não for PLAINTEXT)


### PR DESCRIPTION
Corrige os 3 achados em aberto encontrados na validação de fluxos.

## #1 — dependency_coordinator esperava timeout (~10min)
`flow_c_orchestrator` copiava `dependencies` como task_ids (`task_5`), mas o worker resolve via `get_ticket(ticket_id)` → 404 → o coordinator nunca via o estado → timeout completo. (O caminho Temporal já traduzia.) Fix: map `task_id→ticket_id` + tradução das dependências.

## #2 — QUERY do template ia ao DB vazio
O resolver era totalmente idempotente com `collection` (template), mas o template não fornece `query_type`/`database` → query no DB default `neural_hive_workers` (vazio). Fix: garantir `query_type`/`database` também no template, preservando collection/filter/limit. Teste atualizado.

## #3 — consensus consumer ficava preso
Sem `max.poll.interval.ms` → default 5min. Processar 5 especialistas gRPC + consolidação podia exceder 5min → broker expulsava o consumer. Fix: `kafka_max_poll_interval_ms` configurável (default 30min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)