### PR TITLE
fix(nlu-service): desempacotar tuplo de _detect_language no parse

### DIFF
--- a/services/nlu-service/src/services/nlu_pipeline.py
+++ b/services/nlu-service/src/services/nlu_pipeline.py
@@ -579,8 +579,8 @@ class NLUPipelineService:
             if span:
                 span.set_attribute("nlu.cache_hit", False)
 
-            # Detectar idioma
-            detected_lang = await self._detect_language(text, language)
+            # Detectar idioma (_detect_language devolve tuplo (lang, confiança))
+            detected_lang, _lang_confidence = await self._detect_language(text, language)
             nlp_model = self._get_model_for_language(detected_lang)
 
             # Normalizar e processar


### PR DESCRIPTION
## Summary

Corrige o bloqueador final da cadeia NLU gateway→nlu-service (gRPC).

O método `_detect_language` devolve um tuplo `(lang, confiança)`, mas o método `parse` atribuía-o diretamente a `detected_lang` e usava-o como string em `original_language=detected_lang` ao construir o `NLUResult`.

Resultado: Pydantic `ValidationError` no nlu-service (`original_language Input should be a valid string, input_value=('pt', 1.0)`), propagado como erro gRPC ao gateway, que caía no `_fallback_classify` (TECHNICAL 0.4) em vez de devolver a classificação real (ex.: SECURITY 0.95).

## Changes Made

- `services/nlu-service/src/services/nlu_pipeline.py`: desempacota o tuplo no `parse` (`detected_lang, _lang_confidence = await self._detect_language(...)`), garantindo que `original_language`, `_get_model_for_language` e `_classify_domain` recebem a string do idioma.

## Testing

- `py_compile` OK.
- A validar E2E após deploy: frase sem acentos ("Auditar seguranca e autenticacao") via gateway → SECURITY ~0.95 com nlu-service a receber as chamadas gRPC (sem fallback).

Fecha a cadeia de PRs #126/#127/#129 (normalização de acentos, imports do gateway, delegação gRPC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)