### PR TITLE
fix(gateway): converter enum proto UnifiedDomain (int) ao mapear domain NLU

### DIFF
--- a/services/gateway-intencoes/src/services/nlu_service_adapter.py
+++ b/services/gateway-intencoes/src/services/nlu_service_adapter.py
@@ -10,6 +10,7 @@ from typing import Any
 from grpc_clients.nlu_client import NLUServiceClient
 from grpc_clients.pii_client import PIIServiceClient
 from neural_hive_domain import UnifiedDomain
+from proto import nlu_pb2
 
 from models.intent_envelope import Entity, NLUResult
 
@@ -111,7 +112,7 @@ class NLUServiceAdapter:
             return NLUResult(
                 processed_text=processed_text,
                 domain=domain,
-                classification=nlu_response.domain,  # Usar domain como classification
+                classification=domain.value,  # Usar domain (string) como classification
                 confidence=nlu_response.confidence,
                 entities=entities,
                 keywords=keywords,
@@ -127,9 +128,20 @@ class NLUServiceAdapter:
                 return self._fallback_classify(text, language)
             raise
 
-    def _convert_domain(self, domain_str: str) -> UnifiedDomain:
-        """Converte string do NLU Service para UnifiedDomain."""
+    def _convert_domain(self, domain_value) -> UnifiedDomain:
+        """Converte domain do NLU Service para UnifiedDomain.
+
+        O campo `domain` do proto NLUResult é um enum `UnifiedDomain`, que o
+        protobuf representa em Python como `int` (ex.: SECURITY=4). Aceita também
+        string por robustez. Converte o enum para o seu nome antes de mapear.
+        """
         try:
+            # Enum proto chega como int; converter para o nome (ex.: 4 → "SECURITY").
+            if isinstance(domain_value, int):
+                domain_str = nlu_pb2.UnifiedDomain.Name(domain_value)
+            else:
+                domain_str = str(domain_value)
+
             # Mapeamento NLU Service → UnifiedDomain
             domain_mapping = {
                 "BUSINESS": UnifiedDomain.BUSINESS,


### PR DESCRIPTION
## Summary

Corrige o **segundo** bloqueador da cadeia NLU, descoberto após o deploy de #131.

Com o nlu-service já a responder corretamente (sem o `ValidationError` de `original_language`), o gateway passou a falhar com `'int' object has no attribute 'upper'`. Causa: o campo `domain` do proto `NLUResult` é um enum `UnifiedDomain`, que o protobuf representa em Python como **int** (SECURITY=4). O `_convert_domain` chamava `domain_str.upper()` diretamente sobre esse int. A exceção era apanhada e caía no `_fallback_classify` (TECHNICAL 0.4), mascarando a classificação real (SECURITY 0.95).

## Changes Made

- `services/gateway-intencoes/src/services/nlu_service_adapter.py`:
  - `_convert_domain` aceita o enum proto (int) e converte para o nome via `nlu_pb2.UnifiedDomain.Name(...)` antes de mapear (continua a aceitar string por robustez).
  - `classification` passa a usar `domain.value` (`"SECURITY"`) em vez do enum int cru, consistente com o caminho de fallback.

## Testing

- `py_compile` OK.
- Validado em runtime: o erro `'int' object has no attribute 'upper'` aparecia nos logs do gateway após o deploy de #131; o nlu-service respondia sem erro (logo o erro era no gateway).
- A validar E2E após deploy: "Auditar seguranca e autenticacao" → SECURITY (~0.95), sem fallback.

Completa a cadeia #126/#127/#129/#131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)