### PR TITLE
fix(gateway): converter enum proto EntityType (int) ao mapear entidades NLU

### DIFF
--- a/services/gateway-intencoes/src/services/nlu_service_adapter.py
+++ b/services/gateway-intencoes/src/services/nlu_service_adapter.py
@@ -72,10 +72,10 @@ class NLUServiceAdapter:
             # Converter domain string para UnifiedDomain
             domain = self._convert_domain(nlu_response.domain)
 
-            # Converter entidades
+            # Converter entidades (entity.type é enum proto EntityType → int)
             entities = [
                 Entity(
-                    type=entity.type,
+                    type=self._entity_type_name(entity.type),
                     value=entity.value,
                     confidence=entity.confidence,
                     start=entity.start if entity.start > 0 else None,
@@ -127,6 +127,20 @@ class NLUServiceAdapter:
                 logger.warning("Falling back to keyword-only classification")
                 return self._fallback_classify(text, language)
             raise
+
+    def _entity_type_name(self, type_value) -> str:
+        """Converte o enum proto EntityType (int) para o seu nome string.
+
+        O campo `type` do proto Entity é um enum `EntityType`, representado em
+        Python como int. O modelo Pydantic `Entity` espera uma string. Aceita
+        também string por robustez.
+        """
+        if isinstance(type_value, int):
+            try:
+                return nlu_pb2.EntityType.Name(type_value)
+            except ValueError:
+                return "ENTITY_UNKNOWN"
+        return str(type_value)
 
     def _convert_domain(self, domain_value) -> UnifiedDomain:
         """Converte domain do NLU Service para UnifiedDomain.


### PR DESCRIPTION
## Summary

Terceiro e último elo da cadeia NLU. Após #132 (domain enum), o gateway passou a falhar com `Entity.type Input should be a valid string, input_value=4`: o campo `type` do proto `Entity` é um enum `EntityType` (int em Python), mas o modelo Pydantic `Entity` do gateway espera string. A exceção caía no `_fallback_classify` (TECHNICAL 0.4).

## Changes Made

- `services/gateway-intencoes/src/services/nlu_service_adapter.py`: novo helper `_entity_type_name` converte o enum proto para o nome (ex.: `4 → "LOC"`) via `nlu_pb2.EntityType.Name(...)`, aplicado a cada entidade. Aceita string por robustez. Mesmo padrão de `_convert_domain` (#132).

## Testing

- `py_compile` OK.
- Revisão completa do proto `NLUResult`/`Entity`: os únicos campos enum são `domain` (#132) e `entity.type` (este PR); restantes são string/double/int. Não deverão surgir mais erros encadeados.
- A validar E2E após deploy: "Auditar seguranca e autenticacao" → SECURITY (~0.95), sem fallback.

Fecha a cadeia #126/#127/#129/#131/#132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)