### PR TITLE
test(gateway): regressão da desserialização proto→Pydantic no NLUServiceAdapter

### DIFF
--- a/services/gateway-intencoes/tests/unit/test_nlu_service_adapter.py
+++ b/services/gateway-intencoes/tests/unit/test_nlu_service_adapter.py
@@ -1,0 +1,73 @@
+"""Testes unitários para o NLUServiceAdapter.
+
+Cobre a lacuna que originou os bugs #131/#132/#133: a resposta do NLU Service
+chega como protobuf, onde os campos enum (`UnifiedDomain`, `EntityType`) são
+representados em Python como `int`. O adapter tem de os converter para os tipos
+que o modelo Pydantic local (`UnifiedDomain` / `Entity.type: str`) espera.
+
+Antes da correção, o adapter usava o int cru:
+  - `_convert_domain(4)` → `(4).upper()` → AttributeError → fallback silencioso.
+  - `Entity(type=4)` → Pydantic ValidationError → fallback silencioso.
+
+O `try/except` amplo do `process()` mascarava ambos como "low confidence 0.4",
+escondendo a classificação real (ex.: SECURITY). Estes testes garantem que a
+desserialização proto→Pydantic permanece correta.
+"""
+
+from proto import nlu_pb2
+from services.nlu_service_adapter import NLUServiceAdapter
+
+
+def _adapter() -> NLUServiceAdapter:
+    """Adapter sem clients — os métodos de conversão são puros."""
+    return NLUServiceAdapter(nlu_client=None, pii_client=None)
+
+
+class TestConvertDomainEnumProto:
+    """`domain` chega como enum proto UnifiedDomain (int)."""
+
+    def test_security_int_mapeia_para_security(self):
+        # SECURITY = 4 no proto; tem de resolver para UnifiedDomain.SECURITY.
+        result = _adapter()._convert_domain(nlu_pb2.UnifiedDomain.SECURITY)
+        assert result.value.upper() == "SECURITY"
+
+    def test_business_int(self):
+        result = _adapter()._convert_domain(nlu_pb2.UnifiedDomain.BUSINESS)
+        assert result.value.upper() == "BUSINESS"
+
+    def test_domain_unknown_int_cai_em_technical(self):
+        result = _adapter()._convert_domain(nlu_pb2.UnifiedDomain.DOMAIN_UNKNOWN)
+        assert result.value.upper() == "TECHNICAL"
+
+    def test_aceita_string_por_robustez(self):
+        # Caminho legado/robustez: string já com o nome do domínio.
+        result = _adapter()._convert_domain("SECURITY")
+        assert result.value.upper() == "SECURITY"
+
+    def test_int_invalido_cai_em_technical(self):
+        # Valor fora do enum não deve rebentar — fallback TECHNICAL.
+        result = _adapter()._convert_domain(9999)
+        assert result.value.upper() == "TECHNICAL"
+
+
+class TestEntityTypeNameEnumProto:
+    """`entity.type` chega como enum proto EntityType (int)."""
+
+    def test_loc_int_mapeia_para_nome(self):
+        # LOC = 4 no proto.
+        assert _adapter()._entity_type_name(nlu_pb2.EntityType.LOC) == "LOC"
+
+    def test_person_int(self):
+        assert _adapter()._entity_type_name(nlu_pb2.EntityType.PERSON) == "PERSON"
+
+    def test_unknown_int(self):
+        assert (
+            _adapter()._entity_type_name(nlu_pb2.EntityType.ENTITY_UNKNOWN)
+            == "ENTITY_UNKNOWN"
+        )
+
+    def test_aceita_string_por_robustez(self):
+        assert _adapter()._entity_type_name("ORG") == "ORG"
+
+    def test_int_invalido_cai_em_unknown(self):
+        assert _adapter()._entity_type_name(9999) == "ENTITY_UNKNOWN"


### PR DESCRIPTION
## Summary

Teste de regressão que fecha definitivamente a cadeia de bugs #131/#132/#133.

**Causa raiz**: a resposta do NLU Service chega como protobuf, onde os enums (`UnifiedDomain`, `EntityType`) são representados em Python como `int`. O `nlu_service_adapter.py` do gateway-intencoes não os desserializava — código divergente do padrão já correto no `unified-gateway`. O `try/except` amplo do `process()` mascarava cada erro como "low confidence 0.4", o que tornou o diagnóstico lento (a classificação real ficava escondida).

## Changes Made

- `services/gateway-intencoes/tests/unit/test_nlu_service_adapter.py` (novo): 10 testes para `_convert_domain` e `_entity_type_name`, cobrindo:
  - enum proto (int) → tipo Pydantic correto (ex.: `UnifiedDomain.SECURITY` → SECURITY; `EntityType.LOC` → "LOC");
  - string (robustez / caminho legado);
  - valores inválidos → fallback seguro (TECHNICAL / ENTITY_UNKNOWN).

## Testing

- `pytest tests/unit/test_nlu_service_adapter.py` → **10 passed** localmente.
- Validação E2E em produção (após deploy de #131/#132/#133): "Auditar seguranca e autenticacao" → **SECURITY 0.95** (sem fallback); "Analisar vendas..." → BUSINESS 0.95; "Migrar... legado..." → INFRASTRUCTURE 0.72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)