### PR TITLE
fix(gateway): corrigir atributo settings.pii_service_timeout no PII client

### DIFF
--- a/services/gateway-intencoes/src/grpc_clients/pii_client.py
+++ b/services/gateway-intencoes/src/grpc_clients/pii_client.py
@@ -97,7 +97,7 @@ class PIIServiceClient:
         try:
             response = await asyncio.wait_for(
                 self._stub.Detect(request),
-                timeout=settings.PII_SERVICE_TIMEOUT or 10.0,
+                timeout=settings.pii_service_timeout or 10.0,
             )
 
             # Converter para lista de dicts
@@ -153,7 +153,7 @@ class PIIServiceClient:
         try:
             response = await asyncio.wait_for(
                 self._stub.Mask(request),
-                timeout=settings.PII_SERVICE_TIMEOUT or 10.0,
+                timeout=settings.pii_service_timeout or 10.0,
             )
 
             logger.debug(f"PII masking applied with strategy: {strategy}")


### PR DESCRIPTION
## Summary

Corrige o bug menor revelado na validação E2E da cadeia NLU. O `pii_client.py` acedia a `settings.PII_SERVICE_TIMEOUT` (uppercase), mas o `Settings` (Pydantic, case-sensitive) define `pii_service_timeout` (lowercase). Resultado: `'Settings' object has no attribute 'PII_SERVICE_TIMEOUT'` em cada chamada `Detect`/`Mask`, fazendo o PII masking falhar (o adapter degradava para texto original).

Mesmo padrão já corrigido para o NLU em #129 (`nlu_service_timeout`).

## Changes Made

- `services/gateway-intencoes/src/grpc_clients/pii_client.py`: 2 ocorrências `settings.PII_SERVICE_TIMEOUT` → `settings.pii_service_timeout` (métodos `detect` e `mask`).

## Verificação adicional

Varri todos os acessos `settings.UPPERCASE` no gateway: o único outro caso (`settings.JWT_SECRET` em `auth.py`) é uma **property** válida definida no Settings — não é bug.

## Testing

- `py_compile` OK.
- A validar após deploy: log `PII masking failed: ... PII_SERVICE_TIMEOUT` deixa de aparecer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)