### PR TITLE
fix(pii-service): passar enum MaskStrategy (não string) ao mask() no handler gRPC

### DIFF
--- a/services/pii-service/src/services/grpc_server.py
+++ b/services/pii-service/src/services/grpc_server.py
@@ -6,6 +6,7 @@ import structlog
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from src.config.settings import get_settings
+from src.models.pii import MaskStrategy
 from src.proto import pii_pb2, pii_pb2_grpc
 from src.services.pii_service import get_pii_service
 
@@ -116,14 +117,16 @@ class PIIGrpcServicer(pii_pb2_grpc.PIIServiceServicer):
             tenant_id = request.context.get("tenant_id")
             user_id = request.context.get("user_id")
 
-            # Mapear estratégia
+            # Mapear estratégia do enum proto para o enum de domínio MaskStrategy.
+            # pii_service.mask() espera o enum (usa strategy.value); passar a string
+            # crua levantava "'str' object has no attribute 'value'".
             strategy_map = {
-                pii_pb2.MASK_FULL: "MASK_FULL",
-                pii_pb2.MASK_PARTIAL: "MASK_PARTIAL",
-                pii_pb2.MASK_REDACT: "MASK_REDACT",
-                pii_pb2.MASK_HASH: "MASK_HASH",
+                pii_pb2.MASK_FULL: MaskStrategy.MASK_FULL,
+                pii_pb2.MASK_PARTIAL: MaskStrategy.MASK_PARTIAL,
+                pii_pb2.MASK_REDACT: MaskStrategy.MASK_REDACT,
+                pii_pb2.MASK_HASH: MaskStrategy.MASK_HASH,
             }
-            strategy = strategy_map.get(request.strategy, "MASK_PARTIAL")
+            strategy = strategy_map.get(request.strategy, MaskStrategy.MASK_PARTIAL)
 
             # Tipos para mascarar
             types_to_mask = [t.name for t in request.types] if request.types else None


### PR DESCRIPTION
## Summary

Corrige o bug no **servidor pii-service** revelado após #135 (que desbloqueou a chamada gRPC do gateway ao PII service). O handler gRPC `Mask` mapeava o enum proto `MaskStrategy` para uma **string** crua (`"MASK_FULL"`) e passava-a a `pii_service.mask()`, que espera o enum de domínio `MaskStrategy` e chama `strategy.value`. Resultado: `gRPC INTERNAL: Mask failed: 'str' object has no attribute 'value'` em cada `Mask`/`DetectAndMask`. O caminho REST passava o enum, por isso só o gRPC falhava.

## Changes Made

- `services/pii-service/src/services/grpc_server.py`: `strategy_map` passa a mapear o enum proto → `MaskStrategy` (enum de domínio), consistente com o contrato de `mask()`. Import de `MaskStrategy`. `DetectAndMask` reusa `self.Mask`, ficando coberto.

## Testing

- `py_compile` OK.
- Nota: 3 testes em `tests/test_pii_service.py` (test_mask_full/partial/redact) falham localmente por divergência de expectativa do output do masker (`[EMAIL]` vs `j***@***`) — **pré-existentes e não relacionados** com esta mudança (testam `mask()` diretamente, não o gRPC).
- A validar E2E: log `Mask failed: 'str' object has no attribute 'value'` deixa de aparecer; PII masking funciona via gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)