### PR TITLE
fix(service-registry): default redis aponta para secret partilhado (evita CrashLoop recorrente)

### DIFF
--- a/helm-charts/service-registry/values-local.yaml
+++ b/helm-charts/service-registry/values-local.yaml
@@ -67,6 +67,10 @@ config:
     clusterNodes:
       - neural-hive-cache.redis-cluster.svc.cluster.local:6379
     password: ""
+    # Local nao depende do secret partilhado: cria o seu proprio Secret
+    # (sobrepoe o default do values.yaml que aponta para `redis-password`).
+    existingSecret: ""
+    existingSecretKey: ""
 
   # OpenTelemetry configuration
   otel:

--- a/helm-charts/service-registry/values.yaml
+++ b/helm-charts/service-registry/values.yaml
@@ -72,13 +72,16 @@ config:
     # 1. External Secrets (recomendado): Defina existingSecret abaixo
     # 2. Manual: Configure password aqui (NAO recomendado para producao)
     password: ""
-    # Nome do secret existente que contem a chave 'redis-password'
-    # Se definido, o chart NAO criara o Secret (usa o existente)
-    existingSecret: ""  # Ex: "service-registry-secret" criado por ExternalSecret
-    # Nome da chave dentro do existingSecret (default: "redis-password")
-    # Util quando o secret externo usa convencao diferente. Ex: o secret
-    # `redis-password` partilhado em neural-hive expoe a chave `password`.
-    existingSecretKey: ""  # Default = "redis-password" se vazio
+    # Por defeito, reutiliza o secret partilhado `redis-password` (chave
+    # `password`) do namespace neural-hive — a fonte canonica da password do
+    # Redis Cluster, ja usada pelos restantes servicos. Evita que o chart crie
+    # um `service-registry-secret` com password vazia quando o deploy nao passa
+    # values de ambiente (causava CrashLoop "Authentication required").
+    # Se definido, o chart NAO cria o Secret proprio (usa o existente).
+    existingSecret: "redis-password"
+    # Nome da chave dentro do existingSecret. O secret partilhado
+    # `redis-password` expoe a password na chave `password`.
+    existingSecretKey: "password"
   otel:
     exporterEndpoint: http://otel-collector:4317
 


### PR DESCRIPTION
## Summary

Resolve de forma **permanente** o CrashLoop recorrente do service-registry (`RedisClusterException: Authentication required`), cuja remediação manual (patch ao secret) era revertida a cada deploy.

### Causa raiz (investigação)

- `helm-charts/service-registry/values.yaml` (default) tinha `config.redis.password: ""` e `config.redis.existingSecret: ""`.
- O template `secret.yaml` faz `redis-password: {{ .Values.config.redis.password | b64enc }}` → com password vazia, gera um `service-registry-secret` com a chave `redis-password` **vazia (0 bytes)**, e o deployment aponta `REDIS_PASSWORD` para ela.
- O pipeline de deploy executa `helm upgrade ... helm-charts/service-registry` apenas com `--set image.tag` (confirmado: release 56 com USER-SUPPLIED VALUES só de `image`). **Nunca passa `-f values-k8s.yaml`** (que já tinha a correção), logo usa sempre os defaults → recria o secret vazio a cada deploy e reverte qualquer patch manual.

### Changes

- `values.yaml`: `existingSecret: "redis-password"`, `existingSecretKey: "password"` — reutiliza o secret partilhado canónico do namespace `neural-hive` (sempre presente, já usado pelos restantes serviços). Com `existingSecret` definido, o chart **não cria** o secret próprio e o deployment aponta para `redis-password/password` (válido).
- `values-local.yaml`: `existingSecret: ""` explícito, para o ambiente local continuar a criar o seu próprio secret (Redis local sem auth).

### Testing / Validação

- `helm lint` OK.
- `helm template` com `values.yaml` default → **0 secrets** renderizados, `REDIS_PASSWORD → redis-password/password`; com `values-local.yaml` → 1 secret (local preservado).
- Aplicado em produção (`helm upgrade` rev 57, imagem `678775b` preservada): service-registry **2/2 Running**, `agents_listed_from_redis count=2`, workers re-registados, **sem** `RedisClusterException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)