### PR TITLE
fix(consensus): PheromoneSignal.created_at tz-aware (desbloqueia processamento de consenso)

### DIFF
--- a/services/consensus-engine/src/models/pheromone_signal.py
+++ b/services/consensus-engine/src/models/pheromone_signal.py
@@ -33,7 +33,12 @@ class PheromoneSignal(BaseModel):
     decision_id: Optional[str] = Field(default=None, description="ID da decisão")
 
     # Metadados
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="Data de criação")
+    # NOTA: usar datetime.now(timezone.utc) (aware), nunca datetime.utcnow() (naive),
+    # senão calculate_current_strength() rebenta com "can't subtract offset-naive
+    # and offset-aware datetimes" ao subtrair de datetime.now(timezone.utc).
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), description="Data de criação"
+    )
     expires_at: datetime = Field(..., description="Expiração do feromônio")
     decay_rate: float = Field(default=0.1, description="Taxa de decay por hora", ge=0.0, le=1.0)
 
@@ -56,6 +61,19 @@ class PheromoneSignal(BaseModel):
         """Garante que domain seja sempre UnifiedDomain"""
         if isinstance(v, str):
             return DomainMapper.normalize(v, "intent_envelope")
+        return v
+
+    @field_validator("created_at", "expires_at", mode="before")
+    @classmethod
+    def ensure_timezone_aware(cls, v):
+        """Garante datetimes tz-aware (UTC).
+
+        Feromônios antigos persistidos no Redis/Mongo podem ter sido criados
+        com datetime.utcnow() (naive); ao reconstruir o modelo, coagimos para
+        UTC-aware para evitar TypeError em subtrações com datetimes aware.
+        """
+        if isinstance(v, datetime) and v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
         return v
 
     def get_redis_key(self) -> str:

--- a/services/consensus-engine/tests/test_pheromone_signal_tz.py
+++ b/services/consensus-engine/tests/test_pheromone_signal_tz.py
@@ -1,0 +1,57 @@
+"""Testes de regressão para timezone-awareness do PheromoneSignal.
+
+Cobre o bug que bloqueava o processamento de consenso: `created_at` usava
+`datetime.utcnow()` (naive). Como `calculate_current_strength()` subtrai
+`created_at` de `datetime.now(timezone.utc)` (aware), o consenso rebentava com
+`TypeError: can't subtract offset-naive and offset-aware datetimes` no passo de
+feromônios — e o offset Kafka não era commitado, prendendo o consumer em loop.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from src.models.pheromone_signal import PheromoneSignal
+
+
+def _signal(**overrides):
+    base = dict(
+        specialist_type="technical",
+        domain="technical",
+        pheromone_type="success",
+        strength=0.8,
+        plan_id="plan-1",
+        intent_id="intent-1",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    base.update(overrides)
+    return PheromoneSignal(**base)
+
+
+class TestPheromoneSignalTimezone:
+    def test_created_at_default_e_aware(self):
+        """O default de created_at tem de ser tz-aware (UTC)."""
+        signal = _signal()
+        assert signal.created_at.tzinfo is not None
+
+    def test_created_at_naive_e_coagido_para_aware(self):
+        """created_at naive (feromônio antigo no Redis) é coagido para UTC-aware."""
+        signal = _signal(created_at=datetime.utcnow())  # naive de proposito
+        assert signal.created_at.tzinfo is not None
+
+    def test_expires_at_naive_e_coagido_para_aware(self):
+        signal = _signal(expires_at=datetime.utcnow() + timedelta(hours=1))
+        assert signal.expires_at.tzinfo is not None
+
+    def test_calculate_current_strength_nao_rebenta_com_created_at_naive(self):
+        """Regressão direta: a subtração aware - (naive coagido) não levanta TypeError."""
+        signal = _signal(strength=0.8, created_at=datetime.utcnow())
+        strength = signal.calculate_current_strength()
+        assert 0.0 <= strength <= 0.8
+
+    def test_decay_temporal_aplicado(self):
+        """Feromônio criado há 10h decai abaixo da força inicial."""
+        signal = _signal(
+            strength=1.0,
+            decay_rate=0.1,
+            created_at=datetime.now(timezone.utc) - timedelta(hours=10),
+        )
+        assert signal.calculate_current_strength() < 1.0


### PR DESCRIPTION
## Summary

Corrige um bug que **bloqueava todo o pipeline de consenso**, descoberto ao revalidar um plano multi-task A→C6.

O consensus coletava as 5 opiniões com sucesso, mas falhava no passo 1 (feromônios) com `TypeError: can't subtract offset-naive and offset-aware datetimes`. Como o `plan_consumer` apanha o erro e **não commita o offset**, a mensagem ficava presa em loop no Kafka — os planos nunca chegavam ao approval (acumulando pending).

### Causa raiz

`PheromoneSignal.created_at` usava `default_factory=datetime.utcnow` (**naive**). `calculate_current_strength()` faz `datetime.now(timezone.utc) - self.created_at` (aware − naive) → `TypeError`. Os feromônios persistidos no Redis com `created_at` naive reproduziam o mesmo erro ao serem desserializados.

## Changes

- `services/consensus-engine/src/models/pheromone_signal.py`:
  - `created_at` default → `lambda: datetime.now(timezone.utc)` (aware).
  - `field_validator ensure_timezone_aware` em `created_at`/`expires_at`: coage datetimes naive (dados antigos no Redis/Mongo) para UTC-aware na reconstrução.
- `services/consensus-engine/tests/test_pheromone_signal_tz.py` (novo): 5 testes de regressão (default aware, naive coagido, decay temporal, e a subtração que era o crash).

## Testing

- `pytest tests/test_pheromone_signal_tz.py` → **5 passed**.
- A validar E2E: o plano preso (offset 96 em `plans.ready`) é reprocessado com sucesso → consenso → approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)