### PR TITLE
fix(orchestration): normalizar filter/limit serializados na query (template path)

### DIFF
--- a/libraries/neural_hive_integration/neural_hive_integration/orchestration/parameter_resolver.py
+++ b/libraries/neural_hive_integration/neural_hive_integration/orchestration/parameter_resolver.py
@@ -84,20 +84,56 @@ def _normalize_entities(raw: Any) -> list[str]:
     return result
 
 
+def _normalize_filter(raw: Any) -> dict[str, Any]:
+    """Normaliza o campo `filter` de uma query para um dict.
+
+    O caminho template pode gerar o `filter` como string serializada (efeito do
+    schema Avro `map<string,string>`, ex.: "{'subject': 'x', 'entities': {...}}").
+    O query_executor passa-o diretamente ao pymongo, que exige um dict — uma string
+    levanta "filter must be an instance of dict". Devolve sempre um dict (vazio se
+    não for desserializável), garantindo uma query válida.
+    """
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw.replace("'", '"'))
+            return parsed if isinstance(parsed, dict) else {}
+        except (json.JSONDecodeError, ValueError):
+            return {}
+    return {}
+
+
+def _normalize_limit(raw: Any, default: int) -> int:
+    """Normaliza o `limit` para int (o template pode entregá-lo como string)."""
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 def _resolve_query_parameters(parameters: dict[str, Any], domain: str | None) -> dict[str, Any]:
     """Completa parâmetros de uma task `query` com o contrato técnico do executor.
 
-    - Caminho template (já tem `collection`): preserva collection/filter/limit, mas
-      garante `query_type` e `database` (o template não os fornece, pelo que a query
-      iria ao DB default `neural_hive_workers`, vazio, em vez de `neural_hive`).
+    - Caminho template (já tem `collection`): preserva collection, mas garante
+      `query_type`/`database` e normaliza `filter` (string→dict) e `limit`
+      (string→int) — o schema Avro `map<string,string>` serializa-os como strings,
+      que o pymongo rejeita.
     - Caminho heurístico (sem `collection`): deriva collection/filter/limit/database
       a partir do domínio e das entities (best-effort).
     """
-    # Caminho template: já tem collection; apenas garantir query_type+database.
+    # Caminho template: já tem collection; garantir query_type+database e
+    # normalizar filter/limit (que chegam serializados como string).
     if parameters.get("collection"):
         resolved = dict(parameters)
         resolved.setdefault("query_type", "mongodb")
         resolved.setdefault("database", DEFAULT_QUERY_DATABASE)
+        if "filter" in resolved:
+            resolved["filter"] = _normalize_filter(resolved.get("filter"))
+        if "limit" in resolved:
+            resolved["limit"] = _normalize_limit(resolved.get("limit"), DEFAULT_QUERY_LIMIT)
         return resolved
 
     domain_key = (domain or "").strip().lower()
@@ -111,8 +147,8 @@ def _resolve_query_parameters(parameters: dict[str, Any], domain: str | None) ->
     # Filtro best-effort: vazio devolve o contexto mais recente da collection do
     # domínio (garante execução com sucesso). As entities resolvidas ficam
     # registadas para rastreabilidade/observabilidade.
-    resolved.setdefault("filter", {})
-    resolved.setdefault("limit", DEFAULT_QUERY_LIMIT)
+    resolved["filter"] = _normalize_filter(parameters.get("filter"))
+    resolved["limit"] = _normalize_limit(parameters.get("limit"), DEFAULT_QUERY_LIMIT)
     resolved["resolved_from_entities"] = entities
 
     logger.info(

--- a/libraries/neural_hive_integration/tests/test_parameter_resolver.py
+++ b/libraries/neural_hive_integration/tests/test_parameter_resolver.py
@@ -96,6 +96,44 @@ class TestIdempotencia:
         result = resolve_ticket_parameters("QUERY", params, domain="security")
         assert result["query_type"] == "neo4j"
 
+
+class TestNormalizacaoFilterLimit:
+    """Filter/limit do caminho template chegam serializados como string (Avro)."""
+
+    def test_filter_string_serializada_vira_dict(self):
+        # Caso real do smoke: pymongo exige dict, recebia string → "filter must be
+        # an instance of dict".
+        params = {
+            "collection": "otimizar",
+            "filter": "{'subject': 'otimizar', 'entities': {'$in': ['a', 'b']}}",
+            "limit": "100",
+        }
+        result = resolve_ticket_parameters("QUERY", params, domain="technical")
+        assert isinstance(result["filter"], dict)
+        assert result["filter"]["subject"] == "otimizar"
+        assert result["filter"]["entities"] == {"$in": ["a", "b"]}
+
+    def test_limit_string_vira_int(self):
+        params = {"collection": "x", "filter": {}, "limit": "100"}
+        result = resolve_ticket_parameters("QUERY", params, domain="technical")
+        assert result["limit"] == 100
+        assert isinstance(result["limit"], int)
+
+    def test_filter_string_invalida_vira_dict_vazio(self):
+        params = {"collection": "x", "filter": "nao-e-json"}
+        result = resolve_ticket_parameters("QUERY", params, domain="technical")
+        assert result["filter"] == {}
+
+    def test_limit_invalido_usa_default(self):
+        params = {"collection": "x", "limit": "abc"}
+        result = resolve_ticket_parameters("QUERY", params, domain="technical")
+        assert result["limit"] == 10  # DEFAULT_QUERY_LIMIT
+
+    def test_heuristico_filter_string_vira_dict(self):
+        params = {"objective": "q", "filter": "{'a': 1}"}
+        result = resolve_ticket_parameters("QUERY", params, domain="security")
+        assert result["filter"] == {"a": 1}
+
     def test_database_explicito_preservado(self):
         params = {"objective": "q", "database": "custom_db"}
         result = resolve_ticket_parameters("QUERY", params, domain="security")


### PR DESCRIPTION
## Summary

Corrige a falha da task QUERY do caminho **template** num plano multi-task, descoberta ao revalidar A→C6.

```
mongodb_query_failed: filter must be an instance of dict, bson.son.SON, ...
'filter': "{'subject': 'otimizar', 'entities': {'$in': [...]}}"  ← STRING
'limit': '100'  ← STRING
```

O schema Avro `map<string,string>` serializa `filter` e `limit` como strings. O `query_executor` passa-os diretamente ao pymongo, que rejeita. A task raiz falhava e as dependentes em cascata (propagação FAILED correta), abortando o plano inteiro. É a mesma classe do #125 (entities serializadas), agora estendida.

## Changes

- `parameter_resolver.py`:
  - `_normalize_filter`: string serializada → `dict` (vazio se não desserializável).
  - `_normalize_limit`: string → `int` (default se inválido).
  - Aplicados nos **dois** caminhos do resolver (template e heurístico).
- `tests/test_parameter_resolver.py`: +5 testes de regressão (filter string→dict, limit string→int, inválidos→default, caminho heurístico).

## Testing

- `pytest tests/test_parameter_resolver.py` → **29 passed** (24 existentes + 5 novos).
- A validar E2E: task QUERY do plano multi-task executa COMPLETED (sem `filter must be an instance of dict`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)