### PR TITLE
fix(data flow): persistir result como objeto JSONB (não string aninhada)

### DIFF
--- a/services/execution-ticket-service/src/database/postgres_client.py
+++ b/services/execution-ticket-service/src/database/postgres_client.py
@@ -1,6 +1,7 @@
 """Cliente PostgreSQL para persistência de tickets usando SQLAlchemy async."""
 
 import asyncio
+import json
 import logging
 from typing import Optional
 
@@ -172,9 +173,12 @@ class PostgresClient:
         if actual_duration_ms is not None:
             values["actual_duration_ms"] = actual_duration_ms
         if result_data is not None:
-            # Merge JSONB: metadata || {"result": result_data} (preserva chaves existentes).
+            # Merge JSONB: metadata || {"result": result_data} (preserva chaves
+            # existentes). Serializa via json.dumps + CAST(... AS JSONB) para o
+            # Postgres parsear como OBJETO JSONB; passar o dict diretamente ao cast
+            # serializa-o como string aninhada (result chega à task seguinte como str).
             values["ticket_metadata"] = TicketORM.ticket_metadata.op("||")(
-                cast({"result": result_data}, JSONB)
+                cast(json.dumps({"result": result_data}), JSONB)
             )
 
         async with self._session_maker() as session:

--- a/services/worker-agents/src/engine/execution_engine.py
+++ b/services/worker-agents/src/engine/execution_engine.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import uuid
 from datetime import datetime, timezone
 
@@ -376,6 +377,12 @@ class ExecutionEngine:
                 dep_ticket = await self.ticket_client.get_ticket(dep_id)
                 dep_meta = dep_ticket.get("metadata") or {}
                 dep_result = dep_meta.get("result")
+                # Defensivo: se o result foi persistido como string JSON, desserializar.
+                if isinstance(dep_result, str):
+                    try:
+                        dep_result = json.loads(dep_result)
+                    except (ValueError, TypeError):
+                        pass
                 if dep_result is not None:
                     dependency_outputs[dep_id] = dep_result
                     # O output efetivo do executor está em result["output"] (contrato


### PR DESCRIPTION
## Summary

Corrige o último elo do data flow multi-task (#140). A injeção funcionava (`dependency_outputs_injected` confirmado), mas o output da QUERY chegava à TRANSFORM como **string JSON** em vez de dict, rebentando com `dictionary update sequence element #0 has length 1; 2 is required`.

### Causa raiz

No `postgres_client`, `cast({"result": result_data}, JSONB)` passava o dict Python diretamente ao `CAST`, o que serializava o `result` aninhado como **string** (`metadata.result` TYPE: str confirmado em runtime).

## Changes

- `execution-ticket-service/postgres_client.py`: `cast(json.dumps({"result": result_data}), JSONB)` — o Postgres parseia a string JSON para um **objeto JSONB**, preservando a estrutura aninhada.
- `worker-agents/execution_engine.py`: `_inject_dependency_outputs` desserializa o result se vier como string (defesa para dados antigos/robustez).

## Testing

- `py_compile` OK.
- A validar E2E: cadeia QUERY→TRANSFORM→VALIDATE COMPLETA, com `input_data` como dict (output da QUERY), sem o erro de dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)