### PR TITLE
fix(e2e): corrigir 3 bugs do cognitive pipeline (consumer approval, stats, data flow workers)

### DIFF
--- a/helm-charts/orchestrator-dynamic/values.yaml
+++ b/helm-charts/orchestrator-dynamic/values.yaml
@@ -428,7 +428,9 @@ config:
   # OPA Policy Engine
   opa:
     enabled: true
-    host: opa.neural-hive-orchestration.svc.cluster.local
+    # Namespace correto: o serviço OPA vive em neural-hive (o namespace
+    # neural-hive-orchestration foi removido na consolidação de namespaces).
+    host: opa.neural-hive.svc.cluster.local
     port: 8181
     timeoutSeconds: 2
     retryAttempts: 3

--- a/services/approval-service/src/clients/mongodb_client.py
+++ b/services/approval-service/src/clients/mongodb_client.py
@@ -4,6 +4,7 @@ MongoDB Client para Approval Service
 Fornece interface async para MongoDB para persistencia de aprovacoes.
 """
 
+from datetime import datetime
 from typing import Any, Optional
 
 import structlog
@@ -14,6 +15,33 @@ from src.config.settings import Settings
 from neural_hive_approval_common import ApprovalDecision, ApprovalRequest, ApprovalStats
 
 logger = structlog.get_logger()
+
+
+def _coerce_to_datetime(value: Any) -> Any:
+    """
+    Garante que valores de data sejam datetime (BSON) e nao string ISO.
+
+    Documentos legados ou mensagens deserializadas via json.loads podem trazer
+    timestamps como string ISO 8601. O MongoDB grava essas strings tal-e-qual,
+    o que quebra agregacoes que usam operadores aritmeticos ($subtract) sobre datas.
+
+    Args:
+        value: Valor potencialmente datetime, string ISO ou None.
+
+    Returns:
+        datetime quando a conversao for possivel; caso contrario, o valor original.
+    """
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            # Suporta sufixo 'Z' (UTC) que fromisoformat nao aceita ate Python < 3.11
+            normalized = value.replace("Z", "+00:00")
+            return datetime.fromisoformat(normalized)
+        except ValueError:
+            # Mantem o valor original se nao for um ISO valido (pipeline e defensiva)
+            return value
+    return value
 
 
 class MongoDBClient:
@@ -97,9 +125,9 @@ class MongoDBClient:
             "status": (
                 approval.status.value if hasattr(approval.status, "value") else approval.status
             ),
-            "requested_at": approval.requested_at,
+            "requested_at": _coerce_to_datetime(approval.requested_at),
             "approved_by": approval.approved_by,
-            "approved_at": approval.approved_at,
+            "approved_at": _coerce_to_datetime(approval.approved_at),
             "rejection_reason": approval.rejection_reason,
             "comments": approval.comments,
             "cognitive_plan": approval.cognitive_plan,
@@ -186,7 +214,7 @@ class MongoDBClient:
         update_data = {
             "status": decision.decision,
             "approved_by": decision.approved_by,
-            "approved_at": decision.approved_at,
+            "approved_at": _coerce_to_datetime(decision.approved_at),
             "comments": decision.comments,
         }
 
@@ -227,8 +255,16 @@ class MongoDBClient:
                     "avg_approval_time": [
                         {"$match": {"status": "approved", "approved_at": {"$ne": None}}},
                         {
+                            # Defensivo: docs legados podem ter datas como string ISO.
+                            # $toDate converte string/datetime para Date; null e ignorado
+                            # pelo $avg, evitando o TypeMismatch do $subtract sobre strings.
                             "$project": {
-                                "approval_time": {"$subtract": ["$approved_at", "$requested_at"]}
+                                "approval_time": {
+                                    "$subtract": [
+                                        {"$toDate": "$approved_at"},
+                                        {"$toDate": "$requested_at"},
+                                    ]
+                                }
                             }
                         },
                         {"$group": {"_id": None, "avg": {"$avg": "$approval_time"}}},

--- a/services/approval-service/tests/unit/test_mongodb_client_dates.py
+++ b/services/approval-service/tests/unit/test_mongodb_client_dates.py
@@ -1,0 +1,145 @@
+"""
+Testes unitarios para coercao de datas no MongoDBClient (BUG P1-stats).
+
+Cobre:
+- _coerce_to_datetime: conversao de string ISO -> datetime, passthrough de
+  datetime/None e tolerancia a strings invalidas.
+- save_approval_request / update_approval_decision: gravam datas como datetime BSON.
+- get_approval_stats: pipeline defensivo usa $toDate, tolerando docs legados
+  com datas em string sem voltar a falhar.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.clients.mongodb_client import MongoDBClient, _coerce_to_datetime
+
+from neural_hive_approval_common import ApprovalDecision, ApprovalRequest, RiskBand
+
+
+class TestCoerceToDatetime:
+    """Testes do helper de coercao de datas"""
+
+    def test_string_iso_convertida_para_datetime(self):
+        result = _coerce_to_datetime("2026-06-07T12:30:00")
+        assert isinstance(result, datetime)
+        assert result == datetime(2026, 6, 7, 12, 30, 0)
+
+    def test_string_iso_com_sufixo_z(self):
+        result = _coerce_to_datetime("2026-06-07T12:30:00Z")
+        assert isinstance(result, datetime)
+        assert result == datetime(2026, 6, 7, 12, 30, 0, tzinfo=timezone.utc)
+
+    def test_datetime_passa_inalterado(self):
+        value = datetime(2026, 6, 7, 12, 30, 0)
+        assert _coerce_to_datetime(value) is value
+
+    def test_none_passa_inalterado(self):
+        assert _coerce_to_datetime(None) is None
+
+    def test_string_invalida_mantida(self):
+        # Pipeline e defensiva; helper nao deve lancar excecao
+        assert _coerce_to_datetime("nao-e-uma-data") == "nao-e-uma-data"
+
+
+def _make_client_with_mock_collection() -> MongoDBClient:
+    """Cria MongoDBClient com collection mockada (AsyncMock) para escrita."""
+    settings = MagicMock()
+    client = MongoDBClient(settings)
+    client.collection = AsyncMock()
+    return client
+
+
+class TestEscritaCoerceDatas:
+    """Garante que novas escritas gravam datas como datetime BSON"""
+
+    @pytest.mark.asyncio()
+    async def test_save_approval_request_grava_datetime(self):
+        client = _make_client_with_mock_collection()
+
+        approval = ApprovalRequest(
+            plan_id="plan-001",
+            intent_id="intent-001",
+            risk_score=0.9,
+            risk_band=RiskBand.HIGH,
+            is_destructive=True,
+            requested_at=datetime(2026, 6, 7, 10, 0, 0),
+            cognitive_plan={"plan_id": "plan-001", "tasks": []},
+        )
+
+        await client.save_approval_request(approval)
+
+        client.collection.insert_one.assert_awaited_once()
+        document = client.collection.insert_one.call_args.args[0]
+        assert isinstance(document["requested_at"], datetime)
+        # approved_at e None neste cenario e deve permanecer None
+        assert document["approved_at"] is None
+
+    @pytest.mark.asyncio()
+    async def test_update_approval_decision_grava_datetime(self):
+        client = _make_client_with_mock_collection()
+        client.collection.update_one.return_value = MagicMock(modified_count=1)
+
+        decision = ApprovalDecision(
+            plan_id="plan-001",
+            decision="approved",
+            approved_by="user@example.com",
+            approved_at=datetime(2026, 6, 7, 11, 0, 0),
+        )
+
+        await client.update_approval_decision("plan-001", decision)
+
+        client.collection.update_one.assert_awaited_once()
+        update_doc = client.collection.update_one.call_args.args[1]["$set"]
+        assert isinstance(update_doc["approved_at"], datetime)
+
+
+class TestPipelineStatsDefensivo:
+    """Garante que get_approval_stats nao falha com datas string (legado)"""
+
+    @pytest.mark.asyncio()
+    async def test_pipeline_usa_to_date(self):
+        client = _make_client_with_mock_collection()
+
+        # Mock do cursor de agregacao
+        aggregate_cursor = MagicMock()
+        aggregate_cursor.to_list = AsyncMock(
+            return_value=[
+                {
+                    "status_counts": [{"_id": "approved", "count": 2}],
+                    "risk_band_pending": [],
+                    "avg_approval_time": [{"_id": None, "avg": 60000}],
+                }
+            ]
+        )
+        client.collection.aggregate = MagicMock(return_value=aggregate_cursor)
+
+        result = await client.get_approval_stats()
+
+        # Verifica que o resultado e processado sem erro
+        assert result.approved_count == 2
+        assert result.avg_approval_time_seconds == 60.0  # 60000 ms -> 60 s
+
+        # Verifica que o pipeline aplica $toDate antes do $subtract (defensivo)
+        pipeline = client.collection.aggregate.call_args.args[0]
+        avg_stage = pipeline[0]["$facet"]["avg_approval_time"]
+        project_stage = next(s for s in avg_stage if "$project" in s)
+        subtract_args = project_stage["$project"]["approval_time"]["$subtract"]
+        assert subtract_args[0] == {"$toDate": "$approved_at"}
+        assert subtract_args[1] == {"$toDate": "$requested_at"}
+
+    @pytest.mark.asyncio()
+    async def test_stats_vazio_retorna_defaults(self):
+        client = _make_client_with_mock_collection()
+        aggregate_cursor = MagicMock()
+        aggregate_cursor.to_list = AsyncMock(return_value=[])
+        client.collection.aggregate = MagicMock(return_value=aggregate_cursor)
+
+        result = await client.get_approval_stats()
+
+        assert result.pending_count == 0
+        assert result.approved_count == 0
+        assert result.rejected_count == 0
+        assert result.avg_approval_time_seconds is None
+        assert result.by_risk_band == {}

--- a/services/execution-ticket-service/src/api/tickets.py
+++ b/services/execution-ticket-service/src/api/tickets.py
@@ -1,6 +1,7 @@
 """API endpoints para operações de tickets."""
 
 import asyncio
+import json
 from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import uuid4
@@ -14,6 +15,39 @@ from ..database import get_mongodb_client, get_postgres_client
 from ..models import ExecutionTicket, JWTToken, TicketStatus, generate_token
 
 router = APIRouter(prefix="/api/v1/tickets")
+
+
+def _deserialize_result(metadata: Optional[dict[str, Any]]) -> Optional[Any]:
+    """Extrai e desserializa o output da execução de metadata["result"].
+
+    O contrato Avro define `metadata` como `map<string>`, pelo que o modelo
+    Pydantic (`ExecutionTicket.metadata: dict[str, str]`) força os valores a
+    string ao serializar. Esta função recupera o `result` como OBJETO JSON,
+    desserializando-o quando foi persistido/serializado como string JSON.
+
+    Args:
+        metadata: Dicionário de metadados do ticket (pode ser None).
+
+    Returns:
+        O result como objeto (dict/list) quando disponível; None caso ausente.
+    """
+    if not isinstance(metadata, dict):
+        return None
+
+    result = metadata.get("result")
+    if result is None:
+        return None
+
+    # Defensivo: se foi serializado como string JSON (via dict[str, str] do
+    # modelo Avro), desserializar de volta para objeto.
+    if isinstance(result, str):
+        try:
+            return json.loads(result)
+        except (ValueError, TypeError):
+            # Mantém a string original se não for JSON válido.
+            return result
+
+    return result
 
 
 class StatusUpdateRequest(BaseModel):
@@ -46,6 +80,53 @@ async def get_ticket(ticket_id: str):
         raise HTTPException(status_code=404, detail="Ticket not found")
 
     return ticket_orm.to_pydantic()
+
+
+class TicketResultResponse(BaseModel):
+    """Resposta com o output da execução do ticket como OBJETO JSON.
+
+    Endpoint dedicado para data flow/consumidores externos: ao contrário de
+    `metadata["result"]` (forçado a string pelo modelo Avro `dict[str, str]`),
+    este devolve `result` como objeto JSON (não string nem null quando presente).
+    """
+
+    ticket_id: str
+    status: str
+    result: Optional[Any] = None
+
+
+@router.get("/{ticket_id}/result", response_model=TicketResultResponse)
+async def get_ticket_result(ticket_id: str):
+    """Retorna o output da execução do ticket como OBJETO JSON.
+
+    Lê o metadata JSONB diretamente do ORM (preservando o objeto) e desserializa
+    `result` quando este foi persistido/serializado como string JSON.
+
+    Args:
+        ticket_id: ID do ticket.
+
+    Returns:
+        TicketResultResponse com `result` como objeto (ou None se ausente).
+
+    Raises:
+        404: Se o ticket não for encontrado.
+    """
+    postgres_client = await get_postgres_client()
+    ticket_orm = await postgres_client.get_ticket_by_id(ticket_id)
+
+    if not ticket_orm:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    # Ler o metadata JSONB cru do ORM (objeto), não a versão serializada do
+    # modelo Avro (que stringifica os valores).
+    metadata = getattr(ticket_orm, "ticket_metadata", None)
+    result = _deserialize_result(metadata)
+
+    return TicketResultResponse(
+        ticket_id=ticket_id,
+        status=getattr(ticket_orm, "status", None) or "UNKNOWN",
+        result=result,
+    )
 
 
 @router.post("/", response_model=ExecutionTicket, status_code=201)

--- a/services/execution-ticket-service/tests/test_tickets_result_endpoint.py
+++ b/services/execution-ticket-service/tests/test_tickets_result_endpoint.py
@@ -1,0 +1,129 @@
+"""Testes para o endpoint GET /api/v1/tickets/{id}/result e helper de desserialização.
+
+Cobre o fix do bug P1-workers (ponto 1): o GET deve devolver o output da execução
+como OBJETO JSON, e não null nem string, mesmo quando o modelo Avro (`metadata`
+como `map<string>`) força os valores a string.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+# Importar módulos - path configurado no conftest.py
+from src.api import tickets as tickets_api
+
+# ---------------------------------------------------------------------------
+# _deserialize_result
+# ---------------------------------------------------------------------------
+
+
+def test_deserialize_result_objeto():
+    """Um result já em objeto é devolvido inalterado."""
+    obj = {"success": True, "output": {"count": 3}}
+    assert tickets_api._deserialize_result({"result": obj}) == obj
+
+
+def test_deserialize_result_string_json():
+    """Um result serializado como string JSON é desserializado para objeto."""
+    obj = {"success": True, "output": {"count": 3}}
+    metadata = {"result": json.dumps(obj)}
+
+    deserialized = tickets_api._deserialize_result(metadata)
+
+    assert deserialized == obj
+    assert isinstance(deserialized, dict)
+
+
+def test_deserialize_result_ausente():
+    """Sem chave result, devolve None."""
+    assert tickets_api._deserialize_result({}) is None
+    assert tickets_api._deserialize_result(None) is None
+
+
+def test_deserialize_result_string_nao_json():
+    """Uma string não-JSON é mantida como está (não rebenta)."""
+    assert tickets_api._deserialize_result({"result": "nao-json"}) == "nao-json"
+
+
+def _make_postgres_client(ticket_orm):
+    """Cria mock de PostgresClient cujo get_ticket_by_id devolve o ORM dado."""
+    client = MagicMock()
+    client.get_ticket_by_id = AsyncMock(return_value=ticket_orm)
+    return client
+
+
+@pytest.mark.asyncio()
+async def test_get_ticket_result_objeto():
+    """O endpoint devolve result como objeto (lido do JSONB cru do ORM)."""
+    ticket_id = str(uuid4())
+    result_obj = {"success": True, "output": {"documents": [{"id": 1}], "count": 1}}
+    ticket_orm = SimpleNamespace(
+        ticket_id=ticket_id,
+        status="COMPLETED",
+        ticket_metadata={"result": result_obj},
+    )
+    client = _make_postgres_client(ticket_orm)
+
+    with patch("src.api.tickets.get_postgres_client", return_value=client):
+        response = await tickets_api.get_ticket_result(ticket_id)
+
+    assert response.ticket_id == ticket_id
+    assert response.status == "COMPLETED"
+    assert response.result == result_obj
+    assert isinstance(response.result, dict)
+
+
+@pytest.mark.asyncio()
+async def test_get_ticket_result_desserializa_string():
+    """Se o result no metadata for string JSON, é devolvido como objeto."""
+    ticket_id = str(uuid4())
+    result_obj = {"success": True, "output": {"rows": [1, 2]}}
+    ticket_orm = SimpleNamespace(
+        ticket_id=ticket_id,
+        status="COMPLETED",
+        ticket_metadata={"result": json.dumps(result_obj)},
+    )
+    client = _make_postgres_client(ticket_orm)
+
+    with patch("src.api.tickets.get_postgres_client", return_value=client):
+        response = await tickets_api.get_ticket_result(ticket_id)
+
+    assert response.result == result_obj
+    assert isinstance(response.result, dict)
+
+
+@pytest.mark.asyncio()
+async def test_get_ticket_result_not_found():
+    """Ticket inexistente devolve 404."""
+    ticket_id = str(uuid4())
+    client = _make_postgres_client(None)
+
+    with (
+        patch("src.api.tickets.get_postgres_client", return_value=client),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await tickets_api.get_ticket_result(ticket_id)
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio()
+async def test_get_ticket_result_sem_result():
+    """Ticket sem result no metadata devolve result=None (não rebenta)."""
+    ticket_id = str(uuid4())
+    ticket_orm = SimpleNamespace(
+        ticket_id=ticket_id,
+        status="RUNNING",
+        ticket_metadata={},
+    )
+    client = _make_postgres_client(ticket_orm)
+
+    with patch("src.api.tickets.get_postgres_client", return_value=client):
+        response = await tickets_api.get_ticket_result(ticket_id)
+
+    assert response.result is None
+    assert response.status == "RUNNING"

--- a/services/orchestrator-dynamic/src/integration/flow_c_consumer.py
+++ b/services/orchestrator-dynamic/src/integration/flow_c_consumer.py
@@ -16,6 +16,7 @@ import time
 
 import structlog
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+from aiokafka.errors import CommitFailedError
 from prometheus_client import Counter
 
 from neural_hive_observability import (
@@ -518,6 +519,11 @@ class FlowCApprovalResponseConsumer:
         self.consumer: AIOKafkaConsumer = None
         self.orchestrator: FlowCOrchestrator = None
         self.running = False
+        # [P0-consumer] Timeout por mensagem: impede que uma mensagem "venenosa"
+        # (ex.: resume_flow_c_after_approval preso em retries de dependência —
+        # OPA/Temporal indisponível) bloqueie indefinidamente o poll loop e
+        # congele o consumo dos restantes planos aprovados. Configurável via env.
+        self.process_timeout_s = float(os.getenv("APPROVAL_RESPONSE_PROCESS_TIMEOUT_S", "180"))
         self.logger = logger.bind(service="approval_response_consumer")
 
     async def start(self):
@@ -535,8 +541,14 @@ class FlowCApprovalResponseConsumer:
             "group_id": self.group_id,
             "auto_offset_reset": "earliest",
             "enable_auto_commit": False,
-            "max_poll_interval_ms": 3600000,  # 1 hora
-            "session_timeout_ms": 30000,
+            # [P0-consumer] Alinhar com FlowCConsumer (6h) para acomodar
+            # execuções longas e evitar rebalance/expulsão do grupo que
+            # deixava o consumer em STATE=Empty.
+            "max_poll_interval_ms": 21600000,  # 6 horas em milissegundos
+            "session_timeout_ms": 30000,  # 30 segundos
+            # [P0-consumer] Heartbeat explícito para manter membership do grupo
+            # estável entre polls.
+            "heartbeat_interval_ms": 3000,  # 3 segundos
             # Não usar value_deserializer - receber bytes crus para
             # evitar erro de codec snappy (mensagens do Approval Service)
             # Importante: não definir compression_type para permitir detectar automaticamente
@@ -582,8 +594,10 @@ class FlowCApprovalResponseConsumer:
         self.logger.info("approval_response_consumer_loop_starting")
         while self.running:
             try:
-                # Fetch messages
-                data = await self.consumer.getmany(timeout_ms=1000, max_records=10)
+                # [P0-consumer] max_records=1: processar uma mensagem de cada vez
+                # reduz a janela de reprocessamento em caso de rebalance e mantém
+                # o commit alinhado com cada mensagem processada.
+                data = await self.consumer.getmany(timeout_ms=1000, max_records=1)
 
                 if data:
                     self.logger.debug(
@@ -600,15 +614,54 @@ class FlowCApprovalResponseConsumer:
                             key=message.key.decode("utf-8") if message.key else None,
                             value_preview=str(message.value)[:200] if message.value else None,
                         )
-                        await self._process_approval_response(message)
+                        # [P0-consumer] Timeout por mensagem: se o processamento
+                        # bloquear além do limite (poison message), registamos e
+                        # avançamos o offset (skip) para não congelar todo o
+                        # consumo. O plano saltado fica logado para reprocessamento.
+                        try:
+                            await asyncio.wait_for(
+                                self._process_approval_response(message),
+                                timeout=self.process_timeout_s,
+                            )
+                        except asyncio.TimeoutError:
+                            self.logger.warning(
+                                "approval_response_processing_timeout",
+                                topic=tp.topic,
+                                partition=tp.partition,
+                                offset=message.offset,
+                                key=message.key.decode("utf-8") if message.key else None,
+                                timeout_s=self.process_timeout_s,
+                                note="poison message saltada para desbloquear o consumo; requer reprocessamento manual",
+                            )
 
                         # Commit offset after successful processing
-                        await self.consumer.commit()
+                        # [P0-consumer] Tratar CommitFailedError explicitamente:
+                        # ocorre tipicamente quando há rebalance entre o poll e o
+                        # commit. Não é fatal — registamos e continuamos. Aceitamos
+                        # semântica at-least-once (a mensagem pode ser reprocessada
+                        # após rebalance), pelo que o processamento deve ser idempotente.
+                        try:
+                            await self.consumer.commit()
+                        except CommitFailedError as commit_error:
+                            self.logger.warning(
+                                "approval_response_commit_failed",
+                                error=str(commit_error),
+                                topic=tp.topic,
+                                partition=tp.partition,
+                                offset=message.offset,
+                                note="rebalance provável; mensagem pode ser reprocessada (at-least-once)",
+                            )
 
+            except asyncio.CancelledError:
+                # [P0-consumer] Propagar cancelamento (shutdown gracioso) sem
+                # registar como erro nem reentrar no loop.
+                self.logger.info("approval_response_consumer_loop_cancelled")
+                raise
             except Exception as e:
-                self.logger.error(
-                    "approval_response_consumption_error", error=str(e), exc_info=True
-                )
+                # [P0-consumer] Qualquer outra exceção não deve matar o loop: é
+                # registada e o loop continua. A supervisão em main.py
+                # (_spawn_supervised) é a salvaguarda final caso o loop saia.
+                self.logger.exception("approval_response_consumption_error", error=str(e))
                 await asyncio.sleep(5)
 
     async def _process_approval_response(self, message):

--- a/services/orchestrator-dynamic/src/main.py
+++ b/services/orchestrator-dynamic/src/main.py
@@ -8,6 +8,7 @@ já contém FIX 2a, 2b, 2c, 3 nativamente em flow_c_orchestrator.py.
 
 import asyncio
 import os
+from collections.abc import Callable, Coroutine
 from contextlib import asynccontextmanager, suppress
 from typing import Any
 
@@ -185,9 +186,121 @@ class AppState:
         self.audit_logger: ModelAuditLogger | None = None
         # Feature Flags Service
         self.feature_flag_service: Any | None = None
+        # [P0-consumer] Flag de shutdown: impede recriação de tasks supervisionadas
+        # durante o encerramento gracioso da aplicação.
+        self.is_shutting_down: bool = False
+        # [P0-consumer] Mapa de tasks supervisionadas (nome -> task) usado para
+        # refletir o estado vivo dos consumers no /ready e para recriação.
+        self.supervised_tasks: dict[str, asyncio.Task] = {}
 
 
 app_state = AppState()
+
+
+def _register_supervised_task(name: str, task: "asyncio.Task") -> None:
+    """
+    [P0-consumer] Regista a task viva tanto no mapa ``supervised_tasks`` como
+    no atributo homónimo de ``app_state`` (quando existir).
+
+    O nome de cada task supervisionada coincide com o nome do atributo em
+    ``AppState`` (ex.: ``approval_response_task``). Manter ambos sincronizados
+    garante que o ``/ready`` e o ``shutdown`` — que leem o atributo fixo —
+    observam SEMPRE a task viva, inclusive após uma recriação pelo supervisor.
+
+    Args:
+        name: Identificador da task (igual ao nome do atributo em AppState).
+        task: Task asyncio a registar como a referência viva.
+    """
+    app_state.supervised_tasks[name] = task
+    # Reflete a task viva no atributo fixo lido por /ready e shutdown.
+    if hasattr(app_state, name):
+        setattr(app_state, name, task)
+
+
+def _spawn_supervised(
+    name: str,
+    coro_factory: Callable[[], Coroutine[Any, Any, Any]],
+) -> "asyncio.Task":
+    """
+    [P0-consumer] Cria uma task asyncio supervisionada.
+
+    Regista um ``add_done_callback`` que, se a task terminar por exceção
+    (e não por cancelamento ou durante shutdown), loga o erro com structlog
+    e RECRIA a task automaticamente. Evita que consumers Kafka morram
+    silenciosamente deixando planos aprovados presos.
+
+    Args:
+        name: Identificador da task (usado em logs e no /ready). Coincide com
+            o nome do atributo correspondente em ``AppState``.
+        coro_factory: Callable sem argumentos que devolve a coroutine a executar.
+            Tem de ser uma factory (não a coroutine direta) para permitir
+            recriação após falha.
+
+    Returns:
+        A task asyncio criada e registada em ``app_state.supervised_tasks`` e
+        no atributo homónimo de ``app_state``.
+    """
+
+    def _on_done(task: asyncio.Task) -> None:
+        # Cancelamento (shutdown) é esperado: não recriar.
+        if task.cancelled():
+            logger.info("supervised_task_cancelled", task_name=name)
+            return
+
+        exc = task.exception()
+        if exc is None:
+            # Terminou normalmente (ex.: loop saiu por running=False no shutdown).
+            logger.info("supervised_task_finished", task_name=name)
+            return
+
+        # Terminou por exceção não tratada.
+        logger.error(
+            "supervised_task_crashed",
+            task_name=name,
+            error=str(exc),
+            exc_info=exc,
+        )
+
+        # Não recriar durante shutdown.
+        if app_state.is_shutting_down:
+            logger.info("supervised_task_not_recreated_shutdown", task_name=name)
+            return
+
+        # Recriar a task para restaurar o consumer.
+        logger.warning("supervised_task_recreating", task_name=name)
+        new_task = asyncio.create_task(coro_factory(), name=name)
+        new_task.add_done_callback(_on_done)
+        # Atualiza mapa E atributo fixo para a task recriada (live state).
+        _register_supervised_task(name, new_task)
+
+    task = asyncio.create_task(coro_factory(), name=name)
+    task.add_done_callback(_on_done)
+    _register_supervised_task(name, task)
+    return task
+
+
+def _is_consumer_task_alive(consumer: Any, task: "asyncio.Task | None") -> bool:
+    """
+    [P0-consumer] Verifica se um consumer está saudável para o /ready.
+
+    Considera saudável apenas quando o objeto consumer reporta ``running=True``
+    E a sua task de fundo existe e NÃO terminou. Assim, se a task morrer
+    silenciosamente (ex.: exceção não tratada antes da supervisão recriar),
+    o readiness reflete o estado real e o K8s pode reiniciar o pod.
+
+    Args:
+        consumer: Instância do consumer (deve ter atributo ``running``).
+        task: Task asyncio que executa o loop ``consume()``.
+
+    Returns:
+        True se o consumer estiver vivo e a processar; False caso contrário.
+    """
+    if consumer is None or task is None:
+        return False
+    if not getattr(consumer, "running", False):
+        return False
+    # task.done() é True se terminou normalmente, por exceção ou cancelamento.
+    return not task.done()
 
 
 @asynccontextmanager
@@ -825,8 +938,10 @@ async def lifespan(app: FastAPI):
                     opa_port=getattr(config, "opa_port", None),
                 )
 
-                # Iniciar Temporal Worker em background
-                app_state.worker_task = asyncio.create_task(app_state.temporal_worker.start())
+                # Iniciar Temporal Worker em background (supervisionado)
+                app_state.worker_task = _spawn_supervised(
+                    "worker_task", lambda: app_state.temporal_worker.start()
+                )
                 logger.info("Temporal Worker iniciado em background")
             except Exception as temporal_init_error:
                 init_metrics.record_component_initialization_status(
@@ -843,14 +958,17 @@ async def lifespan(app: FastAPI):
         else:
             logger.warning("Temporal Worker não inicializado - Temporal client não disponível")
 
-        # Iniciar Kafka Consumer em background
-        app_state.consumer_task = asyncio.create_task(app_state.kafka_consumer.start())
+        # Iniciar Kafka Consumer em background (supervisionado)
+        app_state.consumer_task = _spawn_supervised(
+            "consumer_task", lambda: app_state.kafka_consumer.start()
+        )
         logger.info("Kafka Consumer iniciado em background")
 
-        # GAP-02: Iniciar Execution Result Consumer em background
+        # GAP-02: Iniciar Execution Result Consumer em background (supervisionado)
         if app_state.execution_result_consumer:
-            app_state.execution_result_task = asyncio.create_task(
-                app_state.execution_result_consumer.start()
+            app_state.execution_result_task = _spawn_supervised(
+                "execution_result_task",
+                lambda: app_state.execution_result_consumer.start(),
             )
             logger.info("Execution Result Consumer iniciado em background")
 
@@ -859,8 +977,10 @@ async def lifespan(app: FastAPI):
         app_state.flow_c_consumer = FlowCConsumer(config=config)
         await app_state.flow_c_consumer.start()
 
-        # Iniciar Flow C Consumer em background
-        app_state.flow_c_task = asyncio.create_task(app_state.flow_c_consumer.consume())
+        # Iniciar Flow C Consumer em background (supervisionado)
+        app_state.flow_c_task = _spawn_supervised(
+            "flow_c_task", lambda: app_state.flow_c_consumer.consume()
+        )
         logger.info("Flow C Consumer iniciado em background")
 
         # Inicializar Approval Response Consumer
@@ -868,9 +988,12 @@ async def lifespan(app: FastAPI):
         app_state.approval_response_consumer = FlowCApprovalResponseConsumer(config=config)
         await app_state.approval_response_consumer.start()
 
-        # Iniciar Approval Response Consumer em background
-        app_state.approval_response_task = asyncio.create_task(
-            app_state.approval_response_consumer.consume()
+        # Iniciar Approval Response Consumer em background (supervisionado)
+        # [P0-consumer] CAUSA RAIZ: esta task morria silenciosamente e nada a
+        # recriava, deixando planos aprovados presos. Agora é supervisionada.
+        app_state.approval_response_task = _spawn_supervised(
+            "approval_response_task",
+            lambda: app_state.approval_response_consumer.consume(),
         )
         logger.info("Approval Response Consumer iniciado em background")
 
@@ -880,8 +1003,10 @@ async def lifespan(app: FastAPI):
             app_state.sla_alert_consumer = SLAAlertConsumer()
             await app_state.sla_alert_consumer.start()
 
-            # Iniciar SLA Alerts Consumer em background
-            app_state.sla_alert_task = asyncio.create_task(app_state.sla_alert_consumer.consume())
+            # Iniciar SLA Alerts Consumer em background (supervisionado)
+            app_state.sla_alert_task = _spawn_supervised(
+                "sla_alert_task", lambda: app_state.sla_alert_consumer.consume()
+            )
             logger.info("SLA Alerts Consumer iniciado em background")
 
         # Inicializar Drift Detector se ML habilitado
@@ -970,6 +1095,9 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     logger.info("Encerrando Orchestrator Dynamic")
+    # [P0-consumer] Sinaliza shutdown ANTES de cancelar tasks para que o
+    # supervisor não tente recriá-las.
+    app_state.is_shutting_down = True
 
     try:
         # Parar Flow C Consumer
@@ -1899,7 +2027,11 @@ async def readiness_check():
     Readiness check - verifica se serviço está pronto para receber requisições.
     Valida conexões com Kafka e MongoDB. Temporal é opcional.
     """
-    checks = {"kafka_consumer": False, "flow_c_consumer": False}
+    checks = {
+        "kafka_consumer": False,
+        "flow_c_consumer": False,
+        "approval_response_consumer": False,
+    }
 
     try:
         # Verificar Kafka Consumer (obrigatório)
@@ -1909,6 +2041,14 @@ async def readiness_check():
         # Verificar Flow C Consumer (obrigatório)
         if app_state.flow_c_consumer and app_state.flow_c_consumer.running:
             checks["flow_c_consumer"] = True
+
+        # [P0-consumer] Verificar Approval Response Consumer (obrigatório):
+        # o consumer tem de estar a correr E a sua task de fundo tem de estar
+        # viva (não terminada). Se a task morreu silenciosamente, o /ready
+        # reporta not_ready para que o K8s reinicie o pod.
+        checks["approval_response_consumer"] = _is_consumer_task_alive(
+            app_state.approval_response_consumer, app_state.approval_response_task
+        )
 
         # Temporal é opcional - incluir no status se disponível
         if app_state.temporal_client:
@@ -1920,7 +2060,11 @@ async def readiness_check():
             checks["worker"] = "disabled"
 
         # Ready se componentes obrigatórios estão OK
-        required_checks = [checks["kafka_consumer"], checks["flow_c_consumer"]]
+        required_checks = [
+            checks["kafka_consumer"],
+            checks["flow_c_consumer"],
+            checks["approval_response_consumer"],
+        ]
         all_ready = all(v is True for v in required_checks)
 
         return JSONResponse(

--- a/services/orchestrator-dynamic/tests/unit/test_consumer_supervision.py
+++ b/services/orchestrator-dynamic/tests/unit/test_consumer_supervision.py
@@ -1,0 +1,318 @@
+"""
+Testes unitários para a supervisão de tasks de consumo e para a lógica de
+health/readiness do consumer approval-responses.
+
+Cobre o fix [P0-consumer]: "Consumer approval-responses morre silenciosamente;
+planos aprovados nunca executam".
+
+Valida:
+- ``_spawn_supervised`` recria a task quando esta termina por exceção.
+- ``_spawn_supervised`` NÃO recria quando a task é cancelada.
+- ``_spawn_supervised`` NÃO recria durante shutdown (is_shutting_down=True).
+- ``_is_consumer_task_alive`` reflete corretamente o estado vivo do consumer.
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# As settings são avaliadas no import de src.main; definir env mínimo antes.
+os.environ.setdefault("ENVIRONMENT", "development")
+os.environ.setdefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017")
+os.environ.setdefault("REDIS_CLUSTER_NODES", "localhost:6379")
+
+from src.integration.flow_c_consumer import FlowCApprovalResponseConsumer
+from src.main import (
+    _is_consumer_task_alive,
+    _register_supervised_task,
+    _spawn_supervised,
+    app_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_state():
+    """Garante estado limpo entre testes."""
+    app_state.is_shutting_down = False
+    app_state.supervised_tasks = {}
+    app_state.approval_response_task = None
+    yield
+    app_state.is_shutting_down = False
+    app_state.supervised_tasks = {}
+    app_state.approval_response_task = None
+
+
+class TestSpawnSupervised:
+    """Testes da helper de supervisão de tasks."""
+
+    @pytest.mark.asyncio
+    async def test_recria_task_apos_excecao(self):
+        """Se a coroutine termina por exceção, a task deve ser recriada."""
+        call_count = {"n": 0}
+        recreated = asyncio.Event()
+
+        async def _coro():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # Primeira execução: falha imediatamente.
+                raise RuntimeError("falha simulada do consumer")
+            # Segunda execução (recriada): sinaliza e fica viva.
+            recreated.set()
+            await asyncio.sleep(3600)
+
+        task = _spawn_supervised("approval_response_task", _coro)
+
+        # Aguardar a recriação (callback é agendado no loop após a exceção).
+        await asyncio.wait_for(recreated.wait(), timeout=2.0)
+
+        assert call_count["n"] == 2, "A task deveria ter sido recriada após a exceção"
+
+        # A task registada deve ser a nova (viva), não a original.
+        current = app_state.supervised_tasks["approval_response_task"]
+        assert current is not task
+        assert not current.done()
+
+        # Limpeza.
+        current.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await current
+
+    @pytest.mark.asyncio
+    async def test_nao_recria_em_cancelamento(self):
+        """Cancelamento (shutdown gracioso) NÃO deve recriar a task."""
+        started = asyncio.Event()
+
+        async def _coro():
+            started.set()
+            await asyncio.sleep(3600)
+
+        task = _spawn_supervised("flow_c_task", _coro)
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Dar oportunidade ao callback de correr.
+        await asyncio.sleep(0.05)
+
+        # A task registada deve continuar a ser a cancelada — não houve recriação.
+        assert app_state.supervised_tasks["flow_c_task"] is task
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_nao_recria_durante_shutdown(self):
+        """Durante shutdown, exceção na task NÃO deve recriá-la."""
+        app_state.is_shutting_down = True
+        call_count = {"n": 0}
+
+        async def _coro():
+            call_count["n"] += 1
+            raise RuntimeError("falha durante shutdown")
+
+        task = _spawn_supervised("approval_response_task", _coro)
+
+        # Aguardar a task terminar (por exceção).
+        with pytest.raises(RuntimeError):
+            await task
+
+        # Dar oportunidade ao callback de correr.
+        await asyncio.sleep(0.05)
+
+        assert call_count["n"] == 1, "Não deveria recriar durante shutdown"
+        assert app_state.supervised_tasks["approval_response_task"] is task
+
+
+class TestIsConsumerTaskAlive:
+    """Testes da lógica de health do consumer usada no /ready."""
+
+    class _FakeConsumer:
+        def __init__(self, running: bool):
+            self.running = running
+
+    @pytest.mark.asyncio
+    async def test_vivo_quando_running_e_task_ativa(self):
+        async def _coro():
+            await asyncio.sleep(3600)
+
+        task = asyncio.create_task(_coro())
+        try:
+            assert _is_consumer_task_alive(self._FakeConsumer(True), task) is True
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_morto_quando_task_terminou(self):
+        """Task morta silenciosamente (done) => consumer reportado como não vivo."""
+
+        async def _coro():
+            return None
+
+        task = asyncio.create_task(_coro())
+        await task  # task termina (done)
+
+        assert _is_consumer_task_alive(self._FakeConsumer(True), task) is False
+
+    def test_morto_quando_consumer_none(self):
+        assert _is_consumer_task_alive(None, None) is False
+
+    def test_morto_quando_task_none(self):
+        assert _is_consumer_task_alive(self._FakeConsumer(True), None) is False
+
+    @pytest.mark.asyncio
+    async def test_morto_quando_running_false(self):
+        async def _coro():
+            await asyncio.sleep(3600)
+
+        task = asyncio.create_task(_coro())
+        try:
+            assert _is_consumer_task_alive(self._FakeConsumer(False), task) is False
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+
+class TestReadinessRefleteTaskRecriada:
+    """
+    [P0-consumer] Garante que, APÓS o supervisor recriar a task, o caminho de
+    readiness (atributo fixo ``app_state.approval_response_task`` lido pelo
+    /ready e pelo shutdown) reflete a task NOVA (viva) e não a antiga ``.done()``.
+
+    Sem a sincronização do atributo fixo, o /ready devolveria 503 de forma
+    permanente após qualquer recriação bem-sucedida — anulando o próprio
+    supervisor que o fix introduz.
+    """
+
+    class _FakeConsumer:
+        def __init__(self, running: bool):
+            self.running = running
+
+    @pytest.mark.asyncio
+    async def test_atributo_fixo_aponta_para_task_recriada(self):
+        """Após recriação, app_state.approval_response_task é a task viva."""
+        call_count = {"n": 0}
+        recreated = asyncio.Event()
+
+        async def _coro():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("falha simulada do consumer")
+            recreated.set()
+            await asyncio.sleep(3600)
+
+        original = _spawn_supervised("approval_response_task", _coro)
+
+        # No spawn inicial, o atributo fixo já aponta para a task original.
+        assert app_state.approval_response_task is original
+
+        await asyncio.wait_for(recreated.wait(), timeout=2.0)
+
+        current = app_state.supervised_tasks["approval_response_task"]
+        # DEFEITO original: o atributo fixo ficava preso à task original morta.
+        assert app_state.approval_response_task is current
+        assert app_state.approval_response_task is not original
+        assert original.done()
+        assert not app_state.approval_response_task.done()
+
+        # E o readiness, lendo o atributo fixo, reporta o consumer como vivo.
+        consumer = self._FakeConsumer(True)
+        assert _is_consumer_task_alive(consumer, app_state.approval_response_task) is True
+        # A referência antiga (morta) reportaria not_ready — comprova o contraste.
+        assert _is_consumer_task_alive(consumer, original) is False
+
+        current.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await current
+
+
+class TestConsumeTimeoutPorMensagem:
+    """
+    [P0-consumer] Garante que uma mensagem "venenosa" cujo processamento bloqueia
+    além de ``process_timeout_s`` NÃO congela o poll loop: o timeout é apanhado,
+    registado, e o offset é avançado (commit) para desbloquear o consumo.
+    """
+
+    @pytest.mark.asyncio
+    async def test_poison_message_e_saltada_com_commit(self):
+        consumer = FlowCApprovalResponseConsumer(kafka_bootstrap_servers="localhost:9092")
+        consumer.process_timeout_s = 0.05
+        consumer.running = True
+
+        msg = MagicMock()
+        msg.topic = "cognitive-plans-approval-responses"
+        msg.partition = 0
+        msg.offset = 1
+        msg.key = None
+        msg.value = b"{}"
+        tp = MagicMock()
+
+        chamadas = {"n": 0}
+
+        def _getmany_side(*_args, **_kwargs):
+            chamadas["n"] += 1
+            if chamadas["n"] == 1:
+                return {tp: [msg]}
+            # Segunda iteração: termina o loop.
+            consumer.running = False
+            return {}
+
+        consumer.consumer = MagicMock()
+        consumer.consumer.getmany = AsyncMock(side_effect=_getmany_side)
+        consumer.consumer.commit = AsyncMock()
+
+        async def _processamento_lento(_message):
+            # Bloqueia muito além do timeout configurado (poison message).
+            await asyncio.sleep(5)
+
+        consumer._process_approval_response = _processamento_lento
+
+        # Não deve ficar preso: o timeout salta a mensagem e o loop termina.
+        await asyncio.wait_for(consumer.consume(), timeout=3.0)
+
+        # O offset foi committed apesar do timeout (mensagem saltada).
+        consumer.consumer.commit.assert_awaited()
+
+
+class TestRegisterSupervisedTask:
+    """Testes da helper que sincroniza mapa + atributo fixo de AppState."""
+
+    @pytest.mark.asyncio
+    async def test_atualiza_mapa_e_atributo(self):
+        async def _coro():
+            await asyncio.sleep(3600)
+
+        task = asyncio.create_task(_coro())
+        try:
+            _register_supervised_task("approval_response_task", task)
+            assert app_state.supervised_tasks["approval_response_task"] is task
+            assert app_state.approval_response_task is task
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_nome_sem_atributo_so_atualiza_mapa(self):
+        """Nome sem atributo homónimo em AppState não levanta erro."""
+
+        async def _coro():
+            await asyncio.sleep(3600)
+
+        task = asyncio.create_task(_coro())
+        try:
+            _register_supervised_task("nome_inexistente_xyz", task)
+            assert app_state.supervised_tasks["nome_inexistente_xyz"] is task
+            assert not hasattr(app_state, "nome_inexistente_xyz")
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task

--- a/services/worker-agents/src/engine/execution_engine.py
+++ b/services/worker-agents/src/engine/execution_engine.py
@@ -392,6 +392,14 @@ class ExecutionEngine:
                         if isinstance(dep_result, dict) and "output" in dep_result
                         else dep_result
                     )
+                    # Defensivo: se o output veio como string JSON (serialização
+                    # aninhada), desserializar para que a TRANSFORM receba dict/list
+                    # e não uma string (que partiria aggregate/filter).
+                    if isinstance(last_output, str):
+                        try:
+                            last_output = json.loads(last_output)
+                        except (ValueError, TypeError):
+                            pass
             except Exception as e:
                 self.logger.warning(
                     "dependency_output_fetch_failed",
@@ -697,6 +705,48 @@ class ExecutionEngine:
                 if self.metrics and hasattr(self.metrics, "active_tasks"):
                     self.metrics.active_tasks.set(len(self.active_tasks))
 
+    def _normalize_executor_result(
+        self, result: Any, ticket_id: str | None, task_type: str | None
+    ) -> dict[str, Any]:
+        """Garante que o resultado do executor cumpre o contrato {"success": bool}.
+
+        Os executores devem devolver sempre um dict com a chave `success`. Quando
+        tal não acontece (dict sem `success` ou valor não-dict), esta função
+        normaliza o resultado para um dict de falha explícito, evitando a falha
+        silenciosa em `_execute_ticket` (que marca FAILED com a mensagem genérica
+        "Task execution failed without exception" sempre que `success` é falsy).
+
+        Args:
+            result: Valor devolvido pelo executor.
+            ticket_id: ID do ticket (para log).
+            task_type: Tipo da tarefa (para log).
+
+        Returns:
+            Dict com a chave `success` garantida.
+        """
+        if isinstance(result, dict) and "success" in result:
+            return result
+
+        self.logger.warning(
+            "executor_result_missing_success",
+            ticket_id=ticket_id,
+            task_type=task_type,
+            result_type=type(result).__name__,
+        )
+
+        if isinstance(result, dict):
+            # Preserva o conteúdo devolvido, apenas garante a chave `success`.
+            normalized = dict(result)
+            normalized["success"] = False
+            normalized.setdefault("error", "Executor result missing required 'success' field")
+            return normalized
+
+        return {
+            "success": False,
+            "output": result,
+            "error": "Executor returned a non-dict result without 'success' field",
+        }
+
     async def _execute_task_with_retry(self, ticket: dict[str, Any]) -> dict[str, Any]:
         """Executar tarefa com retry logic"""
         task_type = ticket.get("task_type")
@@ -724,7 +774,14 @@ class ExecutionEngine:
                 )
 
                 # Executar com timeout
-                return await asyncio.wait_for(executor.execute(ticket), timeout=timeout_seconds)
+                exec_result = await asyncio.wait_for(
+                    executor.execute(ticket), timeout=timeout_seconds
+                )
+                # Contrato: o executor deve devolver sempre {"success": bool, ...}.
+                # Defensivo: se um executor devolver um dict sem a chave `success`
+                # (ou um valor não-dict), normalizar para evitar a falha silenciosa
+                # "Task execution failed without exception" em _execute_ticket.
+                return self._normalize_executor_result(exec_result, ticket_id, task_type)
 
             except TimeoutError:
                 last_error = f"Timeout after {timeout_seconds}s"

--- a/services/worker-agents/tests/unit/test_execution_engine_data_flow.py
+++ b/services/worker-agents/tests/unit/test_execution_engine_data_flow.py
@@ -1,0 +1,208 @@
+"""
+Testes unitários para o data flow entre tasks no ExecutionEngine.
+
+Cobre o fix do bug P1-workers:
+- Normalização do resultado do executor (garantir chave `success`), evitando a
+  falha silenciosa "Task execution failed without exception".
+- Injeção dos outputs das dependências como input da task seguinte (QUERY ->
+  TRANSFORM), desserializando outputs em string JSON para dict/list.
+"""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+# Mock neural_hive_observability antes de importar o módulo
+mock_tracer_module = MagicMock()
+mock_tracer_module.get_tracer = MagicMock()
+sys.modules["neural_hive_observability"] = mock_tracer_module
+
+from engine.execution_engine import ExecutionEngine
+
+
+class StubTicketClient:
+    """Cliente de ticket stub que devolve tickets pré-configurados por ID."""
+
+    def __init__(self, tickets_by_id=None):
+        self.tickets_by_id = tickets_by_id or {}
+
+    async def get_ticket(self, ticket_id):
+        return self.tickets_by_id[ticket_id]
+
+
+def _make_engine(ticket_client=None):
+    """Cria um ExecutionEngine com dependências mínimas para testes de unidade."""
+    config = SimpleNamespace(
+        max_concurrent_tasks=5,
+        max_retries_per_ticket=0,
+        retry_backoff_base_seconds=0,
+        retry_backoff_max_seconds=0,
+        task_timeout_multiplier=1.0,
+    )
+    return ExecutionEngine(
+        config=config,
+        ticket_client=ticket_client or StubTicketClient(),
+        result_producer=MagicMock(),
+        dependency_coordinator=MagicMock(),
+        executor_registry=MagicMock(),
+        redis_client=None,
+        metrics=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _normalize_executor_result
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_result_preserva_dict_com_success():
+    """Um resultado válido (com chave success) é devolvido inalterado."""
+    engine = _make_engine()
+    result = {"success": True, "output": {"ok": True}}
+
+    normalized = engine._normalize_executor_result(result, "t-1", "QUERY")
+
+    assert normalized is result
+    assert normalized["success"] is True
+
+
+def test_normalize_result_dict_sem_success_marca_falha():
+    """Dict sem `success` é normalizado para falha explícita, sem perder conteúdo."""
+    engine = _make_engine()
+    result = {"output": {"data": 1}}
+
+    normalized = engine._normalize_executor_result(result, "t-2", "TRANSFORM")
+
+    assert normalized["success"] is False
+    assert normalized["output"] == {"data": 1}
+    assert "error" in normalized
+
+
+def test_normalize_result_nao_dict_marca_falha():
+    """Resultado não-dict é normalizado para dict de falha."""
+    engine = _make_engine()
+
+    normalized = engine._normalize_executor_result("texto", "t-3", "TRANSFORM")
+
+    assert normalized["success"] is False
+    assert normalized["output"] == "texto"
+    assert "error" in normalized
+
+
+# ---------------------------------------------------------------------------
+# _inject_dependency_outputs (data flow QUERY -> TRANSFORM)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_inject_dependency_outputs_query_para_transform():
+    """O output (objeto) de uma QUERY é injetado como input_data da TRANSFORM."""
+    query_output = {"documents": [{"id": 1}, {"id": 2}], "count": 2}
+    query_ticket = {
+        "ticket_id": "query-1",
+        "status": "COMPLETED",
+        "metadata": {"result": {"success": True, "output": query_output}},
+    }
+    client = StubTicketClient({"query-1": query_ticket})
+    engine = _make_engine(client)
+
+    transform_ticket = {
+        "ticket_id": "transform-1",
+        "task_type": "TRANSFORM",
+        "dependencies": ["query-1"],
+        "parameters": {},
+    }
+
+    await engine._inject_dependency_outputs(transform_ticket)
+
+    params = transform_ticket["parameters"]
+    # input_data deve ser o output da QUERY (dict), não string nem None.
+    assert params["input_data"] == query_output
+    assert isinstance(params["input_data"], dict)
+    assert params["dependency_outputs"]["query-1"]["output"] == query_output
+
+
+@pytest.mark.asyncio()
+async def test_inject_dependency_outputs_desserializa_result_string():
+    """Se metadata['result'] vier como string JSON, é desserializado para dict."""
+    query_output = {"rows": [1, 2, 3]}
+    result_obj = {"success": True, "output": query_output}
+    query_ticket = {
+        "ticket_id": "query-2",
+        "status": "COMPLETED",
+        # result persistido como string JSON (contrato Avro dict[str, str]).
+        "metadata": {"result": json.dumps(result_obj)},
+    }
+    client = StubTicketClient({"query-2": query_ticket})
+    engine = _make_engine(client)
+
+    transform_ticket = {
+        "ticket_id": "transform-2",
+        "task_type": "TRANSFORM",
+        "dependencies": ["query-2"],
+        "parameters": {},
+    }
+
+    await engine._inject_dependency_outputs(transform_ticket)
+
+    params = transform_ticket["parameters"]
+    assert params["input_data"] == query_output
+    assert isinstance(params["input_data"], dict)
+
+
+@pytest.mark.asyncio()
+async def test_inject_dependency_outputs_output_string_desserializado():
+    """Se o output vier como string JSON aninhada, é desserializado para input_data."""
+    inner = [{"a": 1}, {"a": 2}]
+    query_ticket = {
+        "ticket_id": "query-3",
+        "status": "COMPLETED",
+        # output como string JSON (serialização aninhada)
+        "metadata": {"result": {"success": True, "output": json.dumps(inner)}},
+    }
+    client = StubTicketClient({"query-3": query_ticket})
+    engine = _make_engine(client)
+
+    transform_ticket = {
+        "ticket_id": "transform-3",
+        "task_type": "TRANSFORM",
+        "dependencies": ["query-3"],
+        "parameters": {},
+    }
+
+    await engine._inject_dependency_outputs(transform_ticket)
+
+    params = transform_ticket["parameters"]
+    # input_data deve ser a lista desserializada, não a string.
+    assert params["input_data"] == inner
+    assert isinstance(params["input_data"], list)
+
+
+@pytest.mark.asyncio()
+async def test_inject_dependency_outputs_preserva_input_data_existente():
+    """Se a task já traz input_data próprio, este não é sobrescrito."""
+    query_ticket = {
+        "ticket_id": "query-4",
+        "status": "COMPLETED",
+        "metadata": {"result": {"success": True, "output": {"x": 1}}},
+    }
+    client = StubTicketClient({"query-4": query_ticket})
+    engine = _make_engine(client)
+
+    transform_ticket = {
+        "ticket_id": "transform-4",
+        "task_type": "TRANSFORM",
+        "dependencies": ["query-4"],
+        "parameters": {"input_data": {"original": True}},
+    }
+
+    await engine._inject_dependency_outputs(transform_ticket)
+
+    assert transform_ticket["parameters"]["input_data"] == {"original": True}


### PR DESCRIPTION
## Resumo

Correção de 3 bugs detetados num teste E2E completo do cognitive pipeline (Gateway → STE → Consensus → Approval → Orchestrator → Workers). O fluxo quebrava na **execução pós-aprovação**: planos aprovados nunca eram executados.

Desenvolvido com pipeline rigoroso (dev → auditoria de qualidade → auditoria de completude → remediação dirigida) + verificação manual. **36 testes novos, todos verdes.**

## Bugs corrigidos

### 🔴 P0 — Orchestrator não executava planos aprovados (`dbff67d5`)
O consumer `cognitive-plans-approval-responses` morria silenciosamente (task asyncio sem supervisão; `/ready` não refletia o consumer → K8s nunca reiniciava). Consumer group ficava `Empty` com lag acumulado.
- `_spawn_supervised` recria a task em exceção (não em cancelamento/shutdown); `_register_supervised_task` sincroniza o atributo lido por `/ready` e shutdown.
- **Timeout por mensagem** (`APPROVAL_RESPONSE_PROCESS_TIMEOUT_S`, default 180s) salta *poison messages* que bloqueavam o poll loop.
- `max_records=1`, tratamento de `CommitFailedError`, config alinhada (max_poll_interval 6h + heartbeat).
- Helm: host OPA corrigido para `opa.neural-hive.svc.cluster.local` (namespace `neural-hive-orchestration` foi removido na consolidação).

### 🟠 P1 — `approval-service` GET /stats HTTP 500 (`043e2f7a`)
Datas gravadas como string ISO → `$subtract` da agregação falhava (`can't $subtract string from string`).
- Datas persistidas como `datetime` BSON (`_coerce_to_datetime`); pipeline defensiva com `$toDate` (tolera docs legados).

### 🟠 P1 — Workers: `result: null` + cascata de falhas (`7503a71b`)
- `_normalize_executor_result` elimina a falha silenciosa ("Task execution failed without exception").
- Data flow query→transform desserializa o output da dependência.
- Endpoint aditivo `GET /{ticket_id}/result` devolve `result` como objeto (preserva o contrato Avro `map<string>`).

## Testes
- orchestrator: 12 · approval-service: 9 · worker-agents: 7 · execution-ticket-service: 8 — **36 passed**. `ruff`/`black` (line-length 100) OK.

## Pós-merge (follow-up)
- Apontar os consumidores (flow_c) para `GET /{id}/result` na integração E2E.
- Redeploy do helm (ou patch do configmap) para aplicar o host OPA no cluster.
- P2 (fora de scope): classificação NLU fraca para domínio *business*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)