### PR TITLE
fix(ci): remover pylint não-instalado do validate-observability (#145)

### DIFF
--- a/.github/workflows/validate-observability.yml
+++ b/.github/workflows/validate-observability.yml
@@ -279,7 +279,10 @@ jobs:
     - name: Linting
       run: |
         poetry run flake8 .
-        poetry run pylint neural_hive_observability/
+        # pylint removido: não é instalado neste workflow (instala só
+        # black/isort/flake8/mypy) → falhava sempre com "command not found".
+        # O projeto usa ruff como substituto de pylint (ver python-linting.yml);
+        # flake8 + mypy + bandit já cobrem este job. Ver #145 / #116.
 
     - name: Type Checking
       run: poetry run mypy neural_hive_observability/


### PR DESCRIPTION
## Resumo

Corrige o step **Linting** do job *Python Library Validation* (`validate-observability.yml`), que falhava com `Command not found: pylint`.

## Causa

O step *Install dev tools* instala `black/isort/flake8/mypy` (sem `pylint`), mas o step *Linting* invocava `poetry run pylint neural_hive_observability/`.

## Fix

Removida a invocação do `pylint`:
- O projeto usa **ruff como substituto de pylint** (`python-linting.yml`).
- O job já corre `flake8` + `mypy` + `bandit`.
- Reintroduzir `pylint` não era opção: sem `.pylintrc`, gera dezenas de avisos pré-existentes (`R0913`, `W0603`, ...) — o `pylint` **nunca correu** aqui.

**Verificado no CI deste PR:** o step *Linting* passa agora ✅ (antes abortava no pylint).

## ⚠️ Âmbito — fix atómico, NÃO faz o job inteiro passar

Remover o `pylint` revelou **fails subsequentes pré-existentes** que estavam mascarados (o job parava no pylint):
- **Type Checking (mypy):** (1) `grpc` sem library stubs; (2) `Source file found twice` — o `build/lib/` contém uma cópia do package, que o mypy analisa em duplicado.
- *Security Scan (bandit)* e *Run Tests* ficam por validar (a jusante do mypy).

Estes pertencem à cadeia de fails crónicos do `main` (#116) e requerem trabalho separado (config mypy + limpeza de `build/`, saneamento da lib). Este PR mantém-se **atómico** para o problema que diagnostiquei em #145. A análise completa da cadeia está documentada em #145.

Refs #145, #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
